### PR TITLE
Use BLE MACs as unique identifiers instead of WiFi MACs

### DIFF
--- a/custom_components/marstek_local_api/binary_sensor.py
+++ b/custom_components/marstek_local_api/binary_sensor.py
@@ -121,9 +121,10 @@ class MarstekBinarySensor(CoordinatorEntity, BinarySensorEntity):
         super().__init__(coordinator)
         self.entity_description = entity_description
         self._attr_has_entity_name = True
-        self._attr_unique_id = f"{entry.data['mac']}_{entity_description.key}"
+        device_mac = entry.data.get("ble_mac") or entry.data.get("wifi_mac")
+        self._attr_unique_id = f"{device_mac}_{entity_description.key}"
         self._attr_device_info = DeviceInfo(
-            identifiers={(DOMAIN, entry.data["mac"])},
+            identifiers={(DOMAIN, device_mac)},
             name=f"Marstek {entry.data['device']}",
             manufacturer="Marstek",
             model=entry.data["device"],

--- a/custom_components/marstek_local_api/config_flow.py
+++ b/custom_components/marstek_local_api/config_flow.py
@@ -177,9 +177,9 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         # Check if user selected "All devices"
         if selected == "__all__":
             # Create multi-device entry
-            # Use a synthetic unique ID based on all MACs
-            all_macs = sorted([d["mac"] for d in self._discovered_devices])
-            unique_id = "_".join(all_macs)
+            # Use a synthetic unique ID based on all IP+port combinations
+            all_ip_ports = sorted([f"{d['ip']}:{DEFAULT_PORT}" for d in self._discovered_devices])
+            unique_id = "_".join(all_ip_ports)
 
             await self.async_set_unique_id(unique_id)
             self._abort_if_unique_id_configured()
@@ -210,7 +210,8 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             return self.async_show_form(step_id="discovery", errors=errors)
 
         # Check if already configured
-        await self.async_set_unique_id(device["mac"])
+        unique_id = f"{device['ip']}:{DEFAULT_PORT}"
+        await self.async_set_unique_id(unique_id)
         self._abort_if_unique_id_configured()
 
         # Create entry for single device
@@ -236,7 +237,8 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 info = await validate_input(self.hass, user_input)
 
                 # Check if already configured
-                await self.async_set_unique_id(info["mac"])
+                unique_id = f"{user_input[CONF_HOST]}:{user_input[CONF_PORT]}"
+                await self.async_set_unique_id(unique_id)
                 self._abort_if_unique_id_configured()
 
                 return self.async_create_entry(
@@ -279,7 +281,8 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             )
 
             # Check if already configured
-            await self.async_set_unique_id(info["mac"])
+            unique_id = f"{host}:{DEFAULT_PORT}"
+            await self.async_set_unique_id(unique_id)
             self._abort_if_unique_id_configured(updates={CONF_HOST: host})
 
             # Store discovery info for confirmation

--- a/custom_components/marstek_local_api/config_flow.py
+++ b/custom_components/marstek_local_api/config_flow.py
@@ -48,10 +48,11 @@ async def validate_input(hass: HomeAssistant, data: dict[str, Any], use_ephemera
 
         # Return info that you want to store in the config entry.
         return {
-            "title": f"{device_info.get('device', 'Marstek Device')} ({device_info.get('wifi_mac', 'Unknown')})",
+            "title": f"{device_info.get('device', 'Marstek Device')} ({device_info.get('ble_mac', device_info.get('wifi_mac', 'Unknown'))})",
             "device": device_info.get("device"),
             "firmware": device_info.get("ver"),
-            "mac": device_info.get("wifi_mac"),
+            "wifi_mac": device_info.get("wifi_mac"),
+            "ble_mac": device_info.get("ble_mac"),
         }
 
     except MarstekAPIError as err:
@@ -177,9 +178,9 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         # Check if user selected "All devices"
         if selected == "__all__":
             # Create multi-device entry
-            # Use a synthetic unique ID based on all IP+port combinations
-            all_ip_ports = sorted([f"{d['ip']}:{DEFAULT_PORT}" for d in self._discovered_devices])
-            unique_id = "_".join(all_ip_ports)
+            # Use a synthetic unique ID based on all BLE MACs
+            all_ble_macs = sorted([d["ble_mac"] for d in self._discovered_devices if d.get("ble_mac")])
+            unique_id = "_".join(all_ble_macs)
 
             await self.async_set_unique_id(unique_id)
             self._abort_if_unique_id_configured()
@@ -191,7 +192,8 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                         {
                             CONF_HOST: d["ip"],
                             CONF_PORT: DEFAULT_PORT,
-                            "mac": d["mac"],
+                            "wifi_mac": d.get("wifi_mac"),
+                            "ble_mac": d.get("ble_mac"),
                             "device": d["name"],
                             "firmware": d["firmware"],
                         }
@@ -210,7 +212,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             return self.async_show_form(step_id="discovery", errors=errors)
 
         # Check if already configured
-        unique_id = f"{device['ip']}:{DEFAULT_PORT}"
+        unique_id = device.get("ble_mac") or device.get("mac")
         await self.async_set_unique_id(unique_id)
         self._abort_if_unique_id_configured()
 
@@ -220,7 +222,8 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             data={
                 CONF_HOST: device["ip"],
                 CONF_PORT: DEFAULT_PORT,
-                "mac": device["mac"],
+                "wifi_mac": device.get("wifi_mac"),
+                "ble_mac": device.get("ble_mac"),
                 "device": device["name"],
                 "firmware": device["firmware"],
             },
@@ -237,7 +240,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 info = await validate_input(self.hass, user_input)
 
                 # Check if already configured
-                unique_id = f"{user_input[CONF_HOST]}:{user_input[CONF_PORT]}"
+                unique_id = info.get("ble_mac") or info.get("wifi_mac")
                 await self.async_set_unique_id(unique_id)
                 self._abort_if_unique_id_configured()
 
@@ -246,7 +249,8 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                     data={
                         CONF_HOST: user_input[CONF_HOST],
                         CONF_PORT: user_input[CONF_PORT],
-                        "mac": info["mac"],
+                        "wifi_mac": info["wifi_mac"],
+                        "ble_mac": info["ble_mac"],
                         "device": info["device"],
                         "firmware": info["firmware"],
                     },
@@ -281,7 +285,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             )
 
             # Check if already configured
-            unique_id = f"{host}:{DEFAULT_PORT}"
+            unique_id = info.get("ble_mac") or info.get("wifi_mac")
             await self.async_set_unique_id(unique_id)
             self._abort_if_unique_id_configured(updates={CONF_HOST: host})
 
@@ -290,7 +294,8 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             self.context["device_info"] = {
                 CONF_HOST: host,
                 CONF_PORT: DEFAULT_PORT,
-                "mac": info["mac"],
+                "wifi_mac": info["wifi_mac"],
+                "ble_mac": info["ble_mac"],
                 "device": info["device"],
                 "firmware": info["firmware"],
             }

--- a/custom_components/marstek_local_api/select.py
+++ b/custom_components/marstek_local_api/select.py
@@ -72,10 +72,11 @@ class MarstekOperatingModeSelect(CoordinatorEntity, SelectEntity):
         """Initialize the select."""
         super().__init__(coordinator)
         self._attr_has_entity_name = True
-        self._attr_unique_id = f"{entry.data['mac']}_operating_mode_select"
+        device_mac = entry.data.get("ble_mac") or entry.data.get("wifi_mac")
+        self._attr_unique_id = f"{device_mac}_operating_mode_select"
         self._attr_name = "Operating mode"
         self._attr_device_info = DeviceInfo(
-            identifiers={(DOMAIN, entry.data["mac"])},
+            identifiers={(DOMAIN, device_mac)},
             name=f"Marstek {entry.data['device']}",
             manufacturer="Marstek",
             model=entry.data["device"],

--- a/custom_components/marstek_local_api/sensor.py
+++ b/custom_components/marstek_local_api/sensor.py
@@ -536,9 +536,10 @@ class MarstekSensor(CoordinatorEntity, SensorEntity):
         super().__init__(coordinator)
         self.entity_description = entity_description
         self._attr_has_entity_name = True
-        self._attr_unique_id = f"{entry.data['mac']}_{entity_description.key}"
+        device_mac = entry.data.get("ble_mac") or entry.data.get("wifi_mac")
+        self._attr_unique_id = f"{device_mac}_{entity_description.key}"
         self._attr_device_info = DeviceInfo(
-            identifiers={(DOMAIN, entry.data["mac"])},
+            identifiers={(DOMAIN, device_mac)},
             name=f"Marstek {entry.data['device']}",
             manufacturer="Marstek",
             model=entry.data["device"],


### PR DESCRIPTION
- Update device information in config_flow to include both BLE and WiFi MAC addresses.
- Ensure consistent unique ID usage across configuration flow and entity initialization.
- Prioritize BLE MAC over WiFi MAC in the config_flow

## Validation Performed

- Loaded my repo fork on my HomeAssistant install
- Repeated the problematic config flow & successfully created both HA devices
- Verified that the wifi MACs were in fact still reading as duplicates

<img width="190" height="341" alt="image" src="https://github.com/user-attachments/assets/96c2cbbd-95f1-4707-9561-32144e81956d" />

Addresses https://github.com/jaapp/ha-marstek/issues/3

## NOTE:

- This might break existing entities in HomeAssistant. It's not clear if there are enough users for this to be an issue. 