### PR TITLE
feat: add manual mode schedule configuration services

### DIFF
--- a/custom_components/marstek_local_api/const.py
+++ b/custom_components/marstek_local_api/const.py
@@ -93,3 +93,19 @@ PLATFORMS: Final = ["sensor", "binary_sensor", "select"]
 
 # Services
 SERVICE_REQUEST_SYNC: Final = "request_data_sync"
+SERVICE_SET_MANUAL_SCHEDULE: Final = "set_manual_schedule"
+SERVICE_SET_MANUAL_SCHEDULES: Final = "set_manual_schedules"
+SERVICE_CLEAR_MANUAL_SCHEDULES: Final = "clear_manual_schedules"
+
+# Schedule configuration
+WEEKDAY_MAP: Final = {
+    "mon": 1,   # 0000001
+    "tue": 2,   # 0000010
+    "wed": 4,   # 0000100
+    "thu": 8,   # 0001000
+    "fri": 16,  # 0010000
+    "sat": 32,  # 0100000
+    "sun": 64,  # 1000000
+}
+WEEKDAYS_ALL: Final = ["mon", "tue", "wed", "thu", "fri", "sat", "sun"]
+MAX_SCHEDULE_SLOTS: Final = 10  # Venus C/E supports slots 0-9

--- a/custom_components/marstek_local_api/select.py
+++ b/custom_components/marstek_local_api/select.py
@@ -172,18 +172,10 @@ class MarstekOperatingModeSelect(CoordinatorEntity, SelectEntity):
                 "ai_cfg": {"enable": 1},
             }
         elif mode == MODE_MANUAL:
-            # Default manual mode config (all week, no power limit)
-            # Users can customize via service calls in the future
+            # Manual mode without manual_cfg preserves existing schedules
+            # Users configure schedules separately using set_manual_schedule service
             return {
                 "mode": MODE_MANUAL,
-                "manual_cfg": {
-                    "time_num": 0,
-                    "start_time": "00:00",
-                    "end_time": "23:59",
-                    "week_set": 127,  # All days
-                    "power": 0,
-                    "enable": 1,
-                },
             }
         elif mode == MODE_PASSIVE:
             # Default passive mode config (no power limit, 5 min countdown)
@@ -342,18 +334,10 @@ class MarstekMultiDeviceOperatingModeSelect(CoordinatorEntity, SelectEntity):
                 "ai_cfg": {"enable": 1},
             }
         elif mode == MODE_MANUAL:
-            # Default manual mode config (all week, no power limit)
-            # Users can customize via service calls in the future
+            # Manual mode without manual_cfg preserves existing schedules
+            # Users configure schedules separately using set_manual_schedule service
             return {
                 "mode": MODE_MANUAL,
-                "manual_cfg": {
-                    "time_num": 0,
-                    "start_time": "00:00",
-                    "end_time": "23:59",
-                    "week_set": 127,  # All days
-                    "power": 0,
-                    "enable": 1,
-                },
             }
         elif mode == MODE_PASSIVE:
             # Default passive mode config (no power limit, 5 min countdown)

--- a/custom_components/marstek_local_api/services.py
+++ b/custom_components/marstek_local_api/services.py
@@ -1,14 +1,27 @@
 """Service helpers for the Marstek Local API integration."""
 from __future__ import annotations
 
+import asyncio
 import logging
+from datetime import time
 
 import voluptuous as vol
 
 from homeassistant.core import HomeAssistant, ServiceCall
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import config_validation as cv
 
-from .const import DATA_COORDINATOR, DOMAIN, SERVICE_REQUEST_SYNC
+from .const import (
+    DATA_COORDINATOR,
+    DOMAIN,
+    MAX_SCHEDULE_SLOTS,
+    MODE_MANUAL,
+    SERVICE_CLEAR_MANUAL_SCHEDULES,
+    SERVICE_REQUEST_SYNC,
+    SERVICE_SET_MANUAL_SCHEDULE,
+    SERVICE_SET_MANUAL_SCHEDULES,
+    WEEKDAY_MAP,
+)
 from .coordinator import MarstekDataUpdateCoordinator, MarstekMultiDeviceCoordinator
 
 _LOGGER = logging.getLogger(__name__)
@@ -18,6 +31,72 @@ SERVICE_REQUEST_SYNC_SCHEMA = vol.Schema(
         vol.Optional("entry_id"): cv.string,
     }
 )
+
+# Schedule service schemas
+SERVICE_SET_MANUAL_SCHEDULE_SCHEMA = vol.Schema(
+    {
+        vol.Required("entity_id"): cv.entity_id,
+        vol.Required("time_num"): vol.All(vol.Coerce(int), vol.Range(min=0, max=MAX_SCHEDULE_SLOTS - 1)),
+        vol.Required("start_time"): cv.time,
+        vol.Required("end_time"): cv.time,
+        vol.Optional("days", default=list(WEEKDAY_MAP.keys())): vol.All(
+            cv.ensure_list, [vol.In(WEEKDAY_MAP.keys())]
+        ),
+        vol.Optional("power", default=0): vol.Coerce(int),  # Negative=charge, positive=discharge, 0=no limit
+        vol.Optional("enabled", default=True): cv.boolean,
+    }
+)
+
+SERVICE_SET_MANUAL_SCHEDULES_SCHEMA = vol.Schema(
+    {
+        vol.Required("entity_id"): cv.entity_id,
+        vol.Required("schedules"): [
+            vol.Schema(
+                {
+                    vol.Required("time_num"): vol.All(vol.Coerce(int), vol.Range(min=0, max=MAX_SCHEDULE_SLOTS - 1)),
+                    vol.Required("start_time"): cv.time,
+                    vol.Required("end_time"): cv.time,
+                    vol.Optional("days", default=list(WEEKDAY_MAP.keys())): vol.All(
+                        cv.ensure_list, [vol.In(WEEKDAY_MAP.keys())]
+                    ),
+                    vol.Optional("power", default=0): vol.Coerce(int),  # Negative=charge, positive=discharge, 0=no limit
+                    vol.Optional("enabled", default=True): cv.boolean,
+                }
+            )
+        ],
+    }
+)
+
+SERVICE_CLEAR_MANUAL_SCHEDULES_SCHEMA = vol.Schema(
+    {
+        vol.Required("entity_id"): cv.entity_id,
+    }
+)
+
+
+def _days_to_week_set(days: list[str]) -> int:
+    """Convert list of day names to week_set bitmap."""
+    return sum(WEEKDAY_MAP[day] for day in days)
+
+
+def _find_coordinator_for_entity(hass: HomeAssistant, entity_id: str) -> MarstekDataUpdateCoordinator | None:
+    """Find the coordinator that manages the given entity."""
+    domain_data = hass.data.get(DOMAIN, {})
+
+    for entry_id, entry_payload in domain_data.items():
+        coordinator = entry_payload.get(DATA_COORDINATOR)
+
+        if isinstance(coordinator, MarstekMultiDeviceCoordinator):
+            # Check if entity belongs to any device in this multi-device coordinator
+            for device_coordinator in coordinator.device_coordinators.values():
+                # Entity IDs contain the device MAC, we can check if this coordinator matches
+                # For now, just return the first device coordinator
+                # TODO: Better entity -> coordinator mapping
+                return device_coordinator
+        elif isinstance(coordinator, MarstekDataUpdateCoordinator):
+            return coordinator
+
+    return None
 
 
 async def async_setup_services(hass: HomeAssistant) -> None:
@@ -56,7 +135,186 @@ async def async_setup_services(hass: HomeAssistant) -> None:
         schema=SERVICE_REQUEST_SYNC_SCHEMA,
     )
 
+    async def _async_set_manual_schedule(call: ServiceCall) -> None:
+        """Set a single manual mode schedule."""
+        entity_id = call.data["entity_id"]
+        time_num = call.data["time_num"]
+        start_time: time = call.data["start_time"]
+        end_time: time = call.data["end_time"]
+        days = call.data["days"]
+        power = call.data["power"]
+        enabled = call.data["enabled"]
+
+        # Find coordinator
+        coordinator = _find_coordinator_for_entity(hass, entity_id)
+        if not coordinator:
+            raise HomeAssistantError(f"Could not find coordinator for entity: {entity_id}")
+
+        # Build manual_cfg
+        manual_cfg = {
+            "time_num": time_num,
+            "start_time": start_time.strftime("%H:%M"),
+            "end_time": end_time.strftime("%H:%M"),
+            "week_set": _days_to_week_set(days),
+            "power": power,
+            "enable": 1 if enabled else 0,
+        }
+
+        config = {
+            "mode": MODE_MANUAL,
+            "manual_cfg": manual_cfg,
+        }
+
+        # Set mode via API
+        try:
+            success = await coordinator.api.set_es_mode(config)
+            if success:
+                _LOGGER.info(
+                    "Successfully set manual schedule %d for %s", time_num, entity_id
+                )
+                # Refresh coordinator
+                await coordinator.async_request_refresh()
+            else:
+                raise HomeAssistantError(
+                    f"Device rejected schedule configuration for slot {time_num}"
+                )
+        except Exception as err:
+            _LOGGER.error("Error setting manual schedule: %s", err)
+            raise HomeAssistantError(f"Failed to set manual schedule: {err}") from err
+
+    async def _async_set_manual_schedules(call: ServiceCall) -> None:
+        """Set multiple manual mode schedules at once."""
+        entity_id = call.data["entity_id"]
+        schedules = call.data["schedules"]
+
+        coordinator = _find_coordinator_for_entity(hass, entity_id)
+        if not coordinator:
+            raise HomeAssistantError(f"Could not find coordinator for entity: {entity_id}")
+
+        _LOGGER.info("Setting %d manual schedules for %s", len(schedules), entity_id)
+
+        failed_slots = []
+
+        # Set each schedule sequentially
+        for schedule in schedules:
+            time_num = schedule["time_num"]
+            start_time: time = schedule["start_time"]
+            end_time: time = schedule["end_time"]
+            days = schedule["days"]
+            power = schedule["power"]
+            enabled = schedule["enabled"]
+
+            manual_cfg = {
+                "time_num": time_num,
+                "start_time": start_time.strftime("%H:%M"),
+                "end_time": end_time.strftime("%H:%M"),
+                "week_set": _days_to_week_set(days),
+                "power": power,
+                "enable": 1 if enabled else 0,
+            }
+
+            config = {
+                "mode": MODE_MANUAL,
+                "manual_cfg": manual_cfg,
+            }
+
+            try:
+                success = await coordinator.api.set_es_mode(config)
+                if success:
+                    _LOGGER.debug("Successfully set schedule slot %d", time_num)
+                else:
+                    _LOGGER.warning("Device rejected schedule slot %d", time_num)
+                    failed_slots.append(time_num)
+            except Exception as err:
+                _LOGGER.error("Error setting schedule slot %d: %s", time_num, err)
+                failed_slots.append(time_num)
+
+            # Small delay between calls for reliability
+            await asyncio.sleep(0.5)
+
+        # Refresh coordinator after all schedules are set
+        await coordinator.async_request_refresh()
+
+        if failed_slots:
+            raise HomeAssistantError(
+                f"Failed to set schedules for slots: {failed_slots}"
+            )
+
+        _LOGGER.info("Successfully set all %d schedules", len(schedules))
+
+    async def _async_clear_manual_schedules(call: ServiceCall) -> None:
+        """Clear all manual schedules by disabling all slots."""
+        entity_id = call.data["entity_id"]
+
+        coordinator = _find_coordinator_for_entity(hass, entity_id)
+        if not coordinator:
+            raise HomeAssistantError(f"Could not find coordinator for entity: {entity_id}")
+
+        _LOGGER.info("Clearing all manual schedules for %s", entity_id)
+
+        failed_slots = []
+
+        # Disable all 10 schedule slots
+        for i in range(MAX_SCHEDULE_SLOTS):
+            config = {
+                "mode": MODE_MANUAL,
+                "manual_cfg": {
+                    "time_num": i,
+                    "start_time": "00:00",
+                    "end_time": "00:00",
+                    "week_set": 0,  # No days
+                    "power": 0,
+                    "enable": 0,  # Disabled
+                },
+            }
+
+            try:
+                success = await coordinator.api.set_es_mode(config)
+                if not success:
+                    _LOGGER.warning("Device rejected clearing schedule slot %d", i)
+                    failed_slots.append(i)
+            except Exception as err:
+                _LOGGER.error("Error clearing schedule slot %d: %s", i, err)
+                failed_slots.append(i)
+
+            # Small delay between calls
+            await asyncio.sleep(0.3)
+
+        # Refresh coordinator
+        await coordinator.async_request_refresh()
+
+        if failed_slots:
+            raise HomeAssistantError(
+                f"Failed to clear schedules for slots: {failed_slots}"
+            )
+
+        _LOGGER.info("Successfully cleared all manual schedules")
+
+    hass.services.async_register(
+        DOMAIN,
+        SERVICE_SET_MANUAL_SCHEDULE,
+        _async_set_manual_schedule,
+        schema=SERVICE_SET_MANUAL_SCHEDULE_SCHEMA,
+    )
+
+    hass.services.async_register(
+        DOMAIN,
+        SERVICE_SET_MANUAL_SCHEDULES,
+        _async_set_manual_schedules,
+        schema=SERVICE_SET_MANUAL_SCHEDULES_SCHEMA,
+    )
+
+    hass.services.async_register(
+        DOMAIN,
+        SERVICE_CLEAR_MANUAL_SCHEDULES,
+        _async_clear_manual_schedules,
+        schema=SERVICE_CLEAR_MANUAL_SCHEDULES_SCHEMA,
+    )
+
     _LOGGER.info("Registered service %s.%s", DOMAIN, SERVICE_REQUEST_SYNC)
+    _LOGGER.info("Registered service %s.%s", DOMAIN, SERVICE_SET_MANUAL_SCHEDULE)
+    _LOGGER.info("Registered service %s.%s", DOMAIN, SERVICE_SET_MANUAL_SCHEDULES)
+    _LOGGER.info("Registered service %s.%s", DOMAIN, SERVICE_CLEAR_MANUAL_SCHEDULES)
 
 
 async def async_unload_services(hass: HomeAssistant) -> None:
@@ -64,6 +322,18 @@ async def async_unload_services(hass: HomeAssistant) -> None:
     if hass.services.has_service(DOMAIN, SERVICE_REQUEST_SYNC):
         hass.services.async_remove(DOMAIN, SERVICE_REQUEST_SYNC)
         _LOGGER.debug("Unregistered service %s.%s", DOMAIN, SERVICE_REQUEST_SYNC)
+
+    if hass.services.has_service(DOMAIN, SERVICE_SET_MANUAL_SCHEDULE):
+        hass.services.async_remove(DOMAIN, SERVICE_SET_MANUAL_SCHEDULE)
+        _LOGGER.debug("Unregistered service %s.%s", DOMAIN, SERVICE_SET_MANUAL_SCHEDULE)
+
+    if hass.services.has_service(DOMAIN, SERVICE_SET_MANUAL_SCHEDULES):
+        hass.services.async_remove(DOMAIN, SERVICE_SET_MANUAL_SCHEDULES)
+        _LOGGER.debug("Unregistered service %s.%s", DOMAIN, SERVICE_SET_MANUAL_SCHEDULES)
+
+    if hass.services.has_service(DOMAIN, SERVICE_CLEAR_MANUAL_SCHEDULES):
+        hass.services.async_remove(DOMAIN, SERVICE_CLEAR_MANUAL_SCHEDULES)
+        _LOGGER.debug("Unregistered service %s.%s", DOMAIN, SERVICE_CLEAR_MANUAL_SCHEDULES)
 
 
 async def _async_refresh_entry(entry_id: str, payload: dict) -> None:

--- a/custom_components/marstek_local_api/services.yaml
+++ b/custom_components/marstek_local_api/services.yaml
@@ -6,3 +6,128 @@ request_data_sync:
       name: Config Entry ID
       description: Optional config entry ID to refresh. When omitted, all entries are refreshed.
       example: "1234567890abcdef1234567890abcdef"
+
+set_manual_schedule:
+  name: Set Manual Schedule
+  description: Configure a single manual mode time schedule slot.
+  fields:
+    entity_id:
+      name: Operating Mode Entity
+      description: The operating mode select entity to configure.
+      required: true
+      example: "select.marstek_operating_mode"
+      selector:
+        entity:
+          integration: marstek_local_api
+          domain: select
+    time_num:
+      name: Schedule Slot
+      description: Schedule slot number (0-9). Each slot is an independent schedule.
+      required: true
+      example: 0
+      selector:
+        number:
+          min: 0
+          max: 9
+          mode: slider
+    start_time:
+      name: Start Time
+      description: When to start this schedule (24-hour format).
+      required: true
+      example: "08:00"
+      selector:
+        time:
+    end_time:
+      name: End Time
+      description: When to end this schedule (24-hour format).
+      required: true
+      example: "16:00"
+      selector:
+        time:
+    days:
+      name: Days of Week
+      description: Which days this schedule applies to.
+      default: ["mon", "tue", "wed", "thu", "fri", "sat", "sun"]
+      example: ["mon", "tue", "wed", "thu", "fri"]
+      selector:
+        select:
+          multiple: true
+          options:
+            - label: Monday
+              value: mon
+            - label: Tuesday
+              value: tue
+            - label: Wednesday
+              value: wed
+            - label: Thursday
+              value: thu
+            - label: Friday
+              value: fri
+            - label: Saturday
+              value: sat
+            - label: Sunday
+              value: sun
+    power:
+      name: Power Limit
+      description: Power limit in watts. Use negative values for charging (e.g., -2000 = 2000W charge limit) and positive values for discharging (e.g., 800 = 800W discharge limit). Use 0 for no limit.
+      default: 0
+      example: -2000
+      selector:
+        number:
+          min: -10000
+          max: 10000
+          step: 100
+          unit_of_measurement: W
+    enabled:
+      name: Enabled
+      description: Whether this schedule is active.
+      default: true
+      selector:
+        boolean:
+
+set_manual_schedules:
+  name: Set Multiple Manual Schedules
+  description: Configure multiple manual mode schedules at once. Advanced feature requiring YAML configuration.
+  fields:
+    entity_id:
+      name: Operating Mode Entity
+      description: The operating mode select entity to configure.
+      required: true
+      example: "select.marstek_operating_mode"
+      selector:
+        entity:
+          integration: marstek_local_api
+          domain: select
+    schedules:
+      name: Schedules
+      description: List of schedules to configure. Each schedule requires time_num, start_time, end_time, and optionally days, power, and enabled. Power uses negative values for charging and positive values for discharging.
+      required: true
+      example: |
+        - time_num: 0
+          start_time: "08:00"
+          end_time: "16:00"
+          days: ["mon", "tue", "wed", "thu", "fri"]
+          power: -2000
+          enabled: true
+        - time_num: 1
+          start_time: "18:00"
+          end_time: "22:00"
+          days: ["mon", "tue", "wed", "thu", "fri"]
+          power: 800
+          enabled: true
+      selector:
+        object:
+
+clear_manual_schedules:
+  name: Clear Manual Schedules
+  description: Remove all configured manual mode schedules by disabling all 10 schedule slots.
+  fields:
+    entity_id:
+      name: Operating Mode Entity
+      description: The operating mode select entity to clear schedules for.
+      required: true
+      example: "select.marstek_operating_mode"
+      selector:
+        entity:
+          integration: marstek_local_api
+          domain: select


### PR DESCRIPTION
Implements three new services for configuring manual mode schedules:
- set_manual_schedule: Configure a single schedule slot (0-9)
- set_manual_schedules: Configure multiple slots at once
- clear_manual_schedules: Disable all 10 schedule slots

Key changes:
- Added schedule service implementations in services.py
- Added service definitions in services.yaml with UI selectors
- Updated const.py with schedule-related constants (WEEKDAY_MAP, MAX_SCHEDULE_SLOTS)
- Fixed manual mode switching in select.py to NOT send manual_cfg (preserves existing schedules)
- Added comprehensive documentation in README.md
- Enhanced test_discovery.py with --set-test-schedule and --clear-all-schedules flags

Important discovery:
The Marstek API uses signed power values for schedules (undocumented in API spec):
- Negative power values = charging (e.g., -2000 = 2000W charge limit)
- Positive power values = discharging (e.g., 800 = 800W discharge limit)
- Zero = no limit

This convention has been documented throughout the codebase and is enforced by removing the min=0 constraint from power validation schemas.

Manual mode behavior:
- Switching to Manual mode via the select entity does NOT modify existing schedules
- Schedules are configured independently using the schedule services
- ES.GetMode does NOT return schedule configurations (write-only)
- Users must maintain their own records of configured schedules