### PR TITLE
Fix temperature and remaining capacity values scaling

### DIFF
--- a/custom_components/marstek_local_api/compatibility.py
+++ b/custom_components/marstek_local_api/compatibility.py
@@ -101,6 +101,7 @@ class CompatibilityMatrix:
             (HW_VERSION_2, 0): 1.0,      # FW 0-153: raw value in °C
             (HW_VERSION_2, 154): 0.1,    # FW 154+: raw value in deci-°C (÷0.1 = ×10)
             (HW_VERSION_3, 0): 1.0,      # FW 0+: raw value in °C
+            (HW_VERSION_3, 139): 10.0,   # FW 0+: raw value in deca-°C (÷10)
         },
 
         # Battery capacity (Wh)
@@ -108,6 +109,7 @@ class CompatibilityMatrix:
             (HW_VERSION_2, 0): 100.0,    # FW 0-153: raw value in centi-Wh (÷100)
             (HW_VERSION_2, 154): 1.0,    # FW 154+: raw value in Wh
             (HW_VERSION_3, 0): 1.0,      # FW 0+: raw value in Wh
+            (HW_VERSION_3, 139): 0.1,      # FW 0+: raw value in deci-Wh (÷0.1)
         },
 
         # Battery power (W)


### PR DESCRIPTION
Fix for Venus E V3 fw 139
Temperature and battery remaining capacity before fix:
```
Battery Status
--------------------------------------------------------------------------------
  State of Charge:        45%
  Temperature:            280.0°C
  Remaining Capacity:     230.0 Wh
  Rated Capacity:         5120.0 Wh
  Charging Enabled:       True
  Discharging Enabled:    True
```

after 
```
Battery Status
--------------------------------------------------------------------------------
  State of Charge:        45%
  Temperature:            28.0°C
  Remaining Capacity:     2300.0 Wh
  Rated Capacity:         5120.0 Wh
  Charging Enabled:       True
  Discharging Enabled:    True
```