### PR TITLE
fix: multiply staleness threshold by category-specific factors

### DIFF
--- a/custom_components/marstek_local_api/coordinator.py
+++ b/custom_components/marstek_local_api/coordinator.py
@@ -277,6 +277,15 @@ class MarstekDataUpdateCoordinator(DataUpdateCoordinator):
         # Staleness tracking - track last successful update per category
         self.category_last_updated: dict[str, float] = {}
         self.STALENESS_THRESHOLD = 3  # missed updates before invalidation
+        self.STALENESS_FACTOR = {
+            "battery": UPDATE_INTERVAL_FAST,
+            "es": UPDATE_INTERVAL_FAST,
+            "em": UPDATE_INTERVAL_MEDIUM,
+            "pv": UPDATE_INTERVAL_MEDIUM,
+            "mode": UPDATE_INTERVAL_MEDIUM,
+            "ble": UPDATE_INTERVAL_SLOW,
+            "wifi": UPDATE_INTERVAL_SLOW,
+        }
         self.STATIC_CATEGORIES = {"device", "wifi", "ble", "_diagnostic", "aggregates"}
 
         # Initialize compatibility matrix for version-specific scaling
@@ -393,17 +402,7 @@ class MarstekDataUpdateCoordinator(DataUpdateCoordinator):
         last_update = self.category_last_updated[category]
         elapsed = time.time() - last_update
 
-        stale_factor = {
-            "battery": UPDATE_INTERVAL_FAST,
-            "es": UPDATE_INTERVAL_FAST,
-            "em": UPDATE_INTERVAL_MEDIUM,
-            "pv": UPDATE_INTERVAL_MEDIUM,
-            "mode": UPDATE_INTERVAL_MEDIUM,
-            "ble": UPDATE_INTERVAL_SLOW,
-            "wifi": UPDATE_INTERVAL_SLOW,
-        }
-
-        category_stale_factor = stale_factor.get(category, 1)
+        category_stale_factor = self.STALENESS_FACTOR.get(category, 1)
 
         # Calculate max age (update interval * threshold)
         max_age = self.update_interval.total_seconds() * self.STALENESS_THRESHOLD * category_stale_factor

--- a/custom_components/marstek_local_api/coordinator.py
+++ b/custom_components/marstek_local_api/coordinator.py
@@ -393,8 +393,20 @@ class MarstekDataUpdateCoordinator(DataUpdateCoordinator):
         last_update = self.category_last_updated[category]
         elapsed = time.time() - last_update
 
+        stale_factor = {
+            "battery": UPDATE_INTERVAL_FAST,
+            "es": UPDATE_INTERVAL_FAST,
+            "em": UPDATE_INTERVAL_MEDIUM,
+            "pv": UPDATE_INTERVAL_MEDIUM,
+            "mode": UPDATE_INTERVAL_MEDIUM,
+            "ble": UPDATE_INTERVAL_SLOW,
+            "wifi": UPDATE_INTERVAL_SLOW,
+        }
+
+        category_stale_factor = stale_factor.get(category, 1)
+
         # Calculate max age (update interval * threshold)
-        max_age = self.update_interval.total_seconds() * self.STALENESS_THRESHOLD
+        max_age = self.update_interval.total_seconds() * self.STALENESS_THRESHOLD * category_stale_factor
 
         return elapsed < max_age
 


### PR DESCRIPTION
The staleness function did not take into account the intervals. This PR fixes that.

<img width="569" height="280" alt="image" src="https://github.com/user-attachments/assets/729a213c-ea10-4a90-a0dd-7b1615810fd2" />


<img width="598" height="454" alt="image" src="https://github.com/user-attachments/assets/d58beaf6-027c-498d-b976-a4a2b82c7701" />
