### PR TITLE
Increase _command_delay for executing multiple tasks after eachother.

### DIFF
--- a/custom_components/marstek_local_api/coordinator.py
+++ b/custom_components/marstek_local_api/coordinator.py
@@ -448,7 +448,7 @@ class MarstekDataUpdateCoordinator(DataUpdateCoordinator):
 
             def _command_delay() -> float:
                 """Back off a little between calls; go faster while probing initial contact."""
-                return 0.2 if is_first_update and not had_success else 1.0
+                return 2.0 if is_first_update and not had_success else 5.0
 
             if is_first_update:
                 _LOGGER.debug("First update - fetching device info")


### PR DESCRIPTION
The interval in the proposed official Marstek integration is 2s, and with this my system this indeed seems more stable.