### PR TITLE
fix: correct battery temperature scaling for HW 2.0 FW ≥154 (use divi…

### DIFF
--- a/custom_components/marstek_local_api/compatibility.py
+++ b/custom_components/marstek_local_api/compatibility.py
@@ -99,7 +99,7 @@ class CompatibilityMatrix:
         # Battery temperature (°C)
         "bat_temp": {
             (HW_VERSION_2, 0): 1.0,      # FW 0-153: raw value in °C
-            (HW_VERSION_2, 154): 0.1,    # FW 154+: raw value in deci-°C (÷0.1 = ×10)
+            (HW_VERSION_2, 154): 1,    # FW 154+: raw value in deci-°C
             (HW_VERSION_3, 0): 1.0,      # FW 0+: raw value in °C
             (HW_VERSION_3, 139): 10.0,   # FW 0+: raw value in deca-°C (÷10)
         },


### PR DESCRIPTION
Summary

Fix battery temperature scaling for HW 2.0, FW ≥154.
Problem

Temps shown 10× too high due to divisor 0.1 (raw / 0.1 → ×10).
Change

Set [SCALING_MATRIX['bat_temp'][(HW_VERSION_2, 154)] = 1](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) to use raw °C.
Notes

If devices return deci-°C integers (e.g., 253 → 25.3°C), divisor should be 10.0. Maintainer feedback welcomed on raw unit format.

<img width="320" height="147" alt="image" src="https://github.com/user-attachments/assets/df4ab9a4-3138-4568-9f01-f4d17fa48b30" />
