### PR TITLE
feat: add CT power and energy entities + fix: scaling for v148 and entity mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,8 +83,9 @@ After setup you can return to **Settings → Devices & Services → Marstek Loca
 |  | `total_pv_energy` | kWh | Lifetime PV energy | 1x | 60 |
 |  | `total_grid_import` / `total_grid_export` | kWh | Lifetime grid counters | 1x | 60 |
 |  | `total_load_energy` | kWh | Lifetime load energy | 1x | 60 |
-| **Energy meter / CT** | `ct_phase_a_power`, `ct_phase_b_power`, `ct_phase_c_power` | W | Per-phase measurements (if CTs installed) | 5x | 300 |
-|  | `ct_total_power` | W | CT aggregate | 5x | 300 |
+| **Energy meter / CT** | `ct_phase_a_power`, `ct_phase_b_power`, `ct_phase_c_power` | W | Per-phase measurements (if CTs installed) | 1x | 60 |
+|  | `ct_total_power` | W | CT aggregate | 1x | 60 |
+|  | `ct_input_energy` / `ct_output_energy` | kWh | Lifetime CT energy | 1x | 60 |
 | **Mode** | `operating_mode` | text | Current mode (read-only sensor) | 5x | 300 |
 | **PV (Venus D only)** | `pv_power`, `pv_voltage`, `pv_current` | W / V / A | MPPT telemetry | 5x | 300 |
 | **Network** | `wifi_rssi` | dBm | Wi-Fi signal | 10x | 600 |

--- a/custom_components/marstek_local_api/compatibility.py
+++ b/custom_components/marstek_local_api/compatibility.py
@@ -102,6 +102,7 @@ class CompatibilityMatrix:
             (HW_VERSION_2, 154): 0.1,    # FW 154+: raw value in deci-°C (÷0.1 = ×10)
             (HW_VERSION_3, 0): 1.0,      # FW 0+: raw value in °C
             (HW_VERSION_3, 139): 10.0,   # FW 0+: raw value in deca-°C (÷10)
+            (HW_VERSION_3, 148): 1.0,   # FW 0+: raw value in °C
         },
 
         # Battery capacity (Wh)
@@ -110,6 +111,7 @@ class CompatibilityMatrix:
             (HW_VERSION_2, 154): 1.0,    # FW 154+: raw value in Wh
             (HW_VERSION_3, 0): 1.0,      # FW 0+: raw value in Wh
             (HW_VERSION_3, 139): 0.1,      # FW 0+: raw value in deci-Wh (÷0.1)
+            (HW_VERSION_3, 148): 1.0,      # FW 0+: raw value in Wh (÷0.1)
         },
 
         # Battery power (W)
@@ -150,6 +152,11 @@ class CompatibilityMatrix:
         "bat_current": {
             (HW_VERSION_2, 0): 100.0,    # All FW: raw in centi-A (÷100)
             (HW_VERSION_3, 0): 100.0,    # All FW: raw in centi-A (÷100)
+        },
+
+        # CT energy input/output (Wh) - ALWAYS scaled by 10
+        "ct_energy": {
+            (HW_VERSION_3, 0): 10,    # All FW: raw in deci-Wh (÷10)
         },
     }
 
@@ -219,11 +226,19 @@ class CompatibilityMatrix:
 
         # If no applicable entry (our FW is older than any defined), return raw value
         if not applicable_entries:
+            _LOGGER.debug(
+                "No scaling entries for %s with hw=%s, using raw value",
+                field, self.hardware_version
+            )
             return value
 
         # Get the entry with the highest firmware version
         selected_fw_ver, divisor = max(applicable_entries, key=lambda x: x[0])
         scaled = value / divisor
+        _LOGGER.debug(
+                "Field %s scaled from %f to %f",
+                field, value, scaled
+            )
 
         return scaled
 

--- a/custom_components/marstek_local_api/coordinator.py
+++ b/custom_components/marstek_local_api/coordinator.py
@@ -524,22 +524,32 @@ class MarstekDataUpdateCoordinator(DataUpdateCoordinator):
                 self.category_last_updated["battery"] = time.time()
                 had_success = True
 
+            try:
+                await asyncio.sleep(_command_delay())  # Delay between API calls
+                em_status = await self.api.get_em_status(**_command_kwargs())
+            except Exception as err:
+                _LOGGER.debug("Failed to get EM status: %s", err)
+                em_status = None
+
+            if em_status:
+                if "input_energy" in em_status:
+                    em_status["input_energy"] = self.compatibility.scale_value(
+                        em_status["input_energy"], "ct_energy"
+                    )
+                if "output_energy" in em_status:
+                    em_status["output_energy"] = self.compatibility.scale_value(
+                        em_status["output_energy"], "ct_energy"
+                    )
+                data["em"] = em_status
+                self.category_last_updated["em"] = time.time()
+                had_success = True
+
             # Medium priority - every 5th update (~300s)
             # EM, PV, Mode - slower-changing data
             run_medium = self.update_count == 1 or self.update_count % UPDATE_INTERVAL_MEDIUM == 0
             if is_first_update and not had_success:
                 run_medium = False
             if run_medium:
-                try:
-                    await asyncio.sleep(_command_delay())  # Delay between API calls
-                    em_status = await self.api.get_em_status(**_command_kwargs())
-                    if em_status:
-                        data["em"] = em_status
-                        self.category_last_updated["em"] = time.time()
-                        had_success = True
-                except Exception as err:
-                    _LOGGER.debug("Failed to get EM status: %s", err)
-
                 # Only query PV for Venus D
                 if self.device_model == DEVICE_MODEL_VENUS_D:
                     try:

--- a/custom_components/marstek_local_api/manifest.json
+++ b/custom_components/marstek_local_api/manifest.json
@@ -15,5 +15,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/jaapp/ha-marstek-local-api/issues",
   "requirements": [],
-  "version": "1.2.0.rc7"
+  "version": "1.3.0.rc1"
 }

--- a/custom_components/marstek_local_api/sensor.py
+++ b/custom_components/marstek_local_api/sensor.py
@@ -122,7 +122,7 @@ SENSOR_TYPES: tuple[MarstekSensorEntityDescription, ...] = (
     MarstekSensorEntityDescription(
         key="battery_error_code",
         name="Error code",
-        value_fn=lambda data: data.get("battery", {}).get("error_code"),
+        value_fn=lambda data: data.get("_diagnostic", {}).get("bat_last_error"),
         category="battery",
     ),
     MarstekSensorEntityDescription(
@@ -148,7 +148,7 @@ SENSOR_TYPES: tuple[MarstekSensorEntityDescription, ...] = (
         native_unit_of_measurement=UnitOfPower.WATT,
         device_class=SensorDeviceClass.POWER,
         state_class=SensorStateClass.MEASUREMENT,
-        value_fn=lambda data: max(0, data.get("es", {}).get("bat_power", 0) or 0),
+        value_fn=lambda data: max(0, -(data.get("es", {}).get("ongrid_power", 0) or 0)),
         category="es",
     ),
     MarstekSensorEntityDescription(
@@ -157,15 +157,15 @@ SENSOR_TYPES: tuple[MarstekSensorEntityDescription, ...] = (
         native_unit_of_measurement=UnitOfPower.WATT,
         device_class=SensorDeviceClass.POWER,
         state_class=SensorStateClass.MEASUREMENT,
-        value_fn=lambda data: max(0, -(data.get("es", {}).get("bat_power", 0) or 0)),
+        value_fn=lambda data: max(0, data.get("es", {}).get("ongrid_power", 0) or 0),
         category="es",
     ),
     MarstekSensorEntityDescription(
         key="battery_state",
         name="State",
         value_fn=lambda data: (
-            "charging" if (data.get("es", {}).get("bat_power", 0) or 0) > 0
-            else "discharging" if (data.get("es", {}).get("bat_power", 0) or 0) < 0
+            "charging" if (data.get("es", {}).get("ongrid_power", 0) or 0) < 0
+            else "discharging" if (data.get("es", {}).get("ongrid_power", 0) or 0) > 0
             else "idle"
         ),
         category="es",
@@ -277,6 +277,24 @@ SENSOR_TYPES: tuple[MarstekSensorEntityDescription, ...] = (
         device_class=SensorDeviceClass.POWER,
         state_class=SensorStateClass.MEASUREMENT,
         value_fn=lambda data: data.get("em", {}).get("total_power"),
+        category="em",
+    ),
+    MarstekSensorEntityDescription(
+        key="ct_input_energy",
+        name="CT input energy",
+        native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
+        device_class=SensorDeviceClass.ENERGY,
+        state_class=SensorStateClass.TOTAL_INCREASING,
+        value_fn=lambda data: _wh_to_kwh(data.get("em", {}).get("input_energy")),
+        category="em",
+    ),
+    MarstekSensorEntityDescription(
+        key="ct_output_energy",
+        name="CT output energy",
+        native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
+        device_class=SensorDeviceClass.ENERGY,
+        state_class=SensorStateClass.TOTAL_INCREASING,
+        value_fn=lambda data: _wh_to_kwh(data.get("em", {}).get("output_energy")),
         category="em",
     ),
     MarstekSensorEntityDescription(

--- a/test/test_tool.py
+++ b/test/test_tool.py
@@ -657,6 +657,8 @@ async def discover_and_test(target_ip: str | None) -> None:
                     print(f"  Phase B Power:          {format_value(em_status.get('b_power'), ' W')}")
                     print(f"  Phase C Power:          {format_value(em_status.get('c_power'), ' W')}")
                     print(f"  Total Power:            {format_value(em_status.get('total_power'), ' W')}")
+                    print(f"  Input Energy:           {format_value(em_status.get('input_energy'), ' dWh')}")
+                    print(f"  Output Energy:          {format_value(em_status.get('output_energy'), ' dWh')}")
                 else:
                     print("  (No CT connected)")
             else:


### PR DESCRIPTION
- Added entities for Energy meter/CT Power and Energy (in/out). Now you have all required entities to populate the Energy dashboard.
- Updated polling CT entities to 60 seconds
- Fixed scaling for multiple entities for software version 148
- Fixed battery_error_code, battery_state, battery_power_in, battery_power_out entities to map to correct API field
- Added debug logging for scaling transformation
