### PR TITLE
Add full Marstek Venus A support

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,18 @@
+name: Tests
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  pytest:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+      - name: Install test dependencies
+        run: pip install -r requirements_test.txt
+      - name: Run test suite
+        run: pytest tests

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 > **Firmware warning:** Marstek’s Local API firmware is still immature, so most glitches originate in the batteries, not here.
 > Report issues to Marstek unless you can clearly trace them to this project.
 
-Home Assistant integration that talks directly to Marstek Venus C/D/E batteries over the official Local API. It delivers local-only telemetry, mode control, and fleet-wide aggregation without relying on the Marstek cloud.
+Home Assistant integration that talks directly to Marstek Venus A/C/D/E batteries over the official Local API. It delivers local-only telemetry, mode control, and fleet-wide aggregation without relying on the Marstek cloud.
 
 ---
 
@@ -72,21 +72,22 @@ After setup you can return to **Settings → Devices & Services → Marstek Loca
 |  | `battery_capacity` | kWh | Remaining capacity | 1x | 60 |
 |  | `battery_rated_capacity` | kWh | Rated pack capacity | 1x | 60 |
 |  | `battery_available_capacity` | kWh | Estimated energy still available before full charge | 1x | 60 |
-|  | `battery_voltage` | V | Pack voltage | 1x | 60 |
-|  | `battery_current` | A | Pack current (positive = charge) | 1x | 60 |
-| **Energy system (ES)** | `battery_power` | W | Pack power (positive = charge) | 1x | 60 |
+|  | `battery_voltage` | V | Pack voltage (not reported by Venus A) | 1x | 60 |
+|  | `battery_current` | A | Pack current (positive = charge; not reported by Venus A) | 1x | 60 |
+| **Energy system (ES)** | `battery_power` | W | Pack power (positive = charge; derived from PV/grid flows on Venus A) | 1x | 60 |
 |  | `battery_power_in` / `battery_power_out` | W | Split charge/discharge power | 1x | 60 |
 |  | `battery_state` | text | `charging` / `discharging` / `idle` | 1x | 60 |
 |  | `grid_power` | W | Grid import/export (positive = import) | 1x | 60 |
 |  | `offgrid_power` | W | Off-grid load | 1x | 60 |
-|  | `pv_power_es` | W | Solar production reported via ES | 1x | 60 |
-|  | `total_pv_energy` | kWh | Lifetime PV energy | 1x | 60 |
+|  | `pv_power_es` | W | Solar production reported via ES (on Venus A: sum of the PV strings) | 1x | 60 |
+|  | `total_pv_energy` | kWh | Lifetime PV energy (Venus A firmware reports 0 — disabled by default there) | 1x | 60 |
 |  | `total_grid_import` / `total_grid_export` | kWh | Lifetime grid counters | 1x | 60 |
-|  | `total_load_energy` | kWh | Lifetime load energy | 1x | 60 |
+|  | `total_load_energy` | kWh | Lifetime load energy (Venus A firmware reports 0 — disabled by default there) | 1x | 60 |
 | **Energy meter / CT** | `ct_phase_a_power`, `ct_phase_b_power`, `ct_phase_c_power` | W | Per-phase measurements (if CTs installed) | 5x | 300 |
 |  | `ct_total_power` | W | CT aggregate | 5x | 300 |
 | **Mode** | `operating_mode` | text | Current mode (read-only sensor) | 5x | 300 |
 | **PV (Venus D only)** | `pv_power`, `pv_voltage`, `pv_current` | W / V / A | MPPT telemetry | 5x | 300 |
+| **PV strings (Venus A only)** | `pv1_power` … `pv4_power`, `pv1_voltage` … `pv4_voltage` | W / V | Per-string MPPT telemetry (string current omitted: unit is inconsistent on current firmware) | 1x | 60 |
 | **Network** | `wifi_rssi` | dBm | Wi-Fi signal | 10x | 600 |
 |  | `wifi_ssid`, `wifi_ip`, `wifi_gateway`, `wifi_subnet`, `wifi_dns` | text | Wi-Fi configuration | 10x | 600 |
 | **Device info** | `device_model`, `firmware_version`, `ble_mac`, `wifi_mac`, `device_ip` | text | Identification fields | 10x | 600 |
@@ -266,6 +267,21 @@ automation:
       custom_components.marstek_local_api: debug
   ```
 
+### Energy dashboard (charged / discharged energy)
+
+No Marstek firmware exposes lifetime *battery* charge/discharge counters — the
+`total_grid_import`/`total_grid_export` counters only cover the AC side, so on
+models with MPPT inputs (Venus A/D) they miss energy charged directly from
+solar. To feed the energy dashboard's battery section, create two
+[Riemann sum integral helpers](https://www.home-assistant.io/integrations/integration/)
+(Settings → Devices & services → Helpers → Integral):
+
+- *Energy going in to the battery*: integrate `sensor.<device>_power_in` (method *Left*, unit prefix *k*)
+- *Energy coming out of the battery*: integrate `sensor.<device>_power_out` (method *Left*, unit prefix *k*)
+
+A third helper over `pv_power_es` gives solar production for the dashboard's
+solar section on Venus A.
+
 ## API maturity & known issues
 
 Note: the Marstek Local API is still relatively new and evolving. Behavior can vary between hardware revisions (v2/v3) and firmware versions (EMS and BMS). When reporting issues, always include diagnostic data (logs and the integration's diagnostic fields).
@@ -280,6 +296,12 @@ Known issues:
  - Energy counters / capacity fields may be reported in Wh instead of kWh on certain firmware (values appear 1000× off).
  - `ES.GetStatus` can be unresponsive on some Venus E v3 firmwares (reported on v137 / v139).
  - CT connection state may be reported as "disconnected" / power values might not be updated even when a CT is connected (appears fixed in HW v2 firmware v154+).
+
+Venus A specifics (observed on firmware v148):
+- The device silently drops a large share of UDP requests (no error reply). The integration's retries usually get through, but occasional command timeouts and rejected writes (`set_result: false` while the device is busy) are normal — retry the service call.
+- `ES.GetStatus` does not include `bat_power` and always reports `pv_power`/`total_pv_energy` as 0. The integration derives battery power and solar power from `PV.GetStatus` and the grid flows instead.
+- `Bat.GetStatus` has no voltage/current/error-code fields, and `EM.GetStatus` has no `parse_state` — the corresponding entities are not created for Venus A.
+- The `wifi_mac` reported by the device can be the MAC of your access point rather than the battery's own WiFi module.
 
 Most of these issues are resolved by updating the device to the latest firmware — Marstek staggers rollouts, so many systems still run older versions. The Local API is evolving quickly and should stabilise as updates are deployed.
 

--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ After setup you can return to **Settings → Devices & Services → Marstek Loca
 | **Mode** | `operating_mode` | text | Current mode (read-only sensor) | 5x | 300 |
 | **PV (Venus D only)** | `pv_power`, `pv_voltage`, `pv_current` | W / V / A | MPPT telemetry | 5x | 300 |
 | **PV strings (Venus A only)** | `pv1_power` … `pv4_power`, `pv1_voltage` … `pv4_voltage` | W / V | Per-string MPPT telemetry (string current omitted: unit is inconsistent on current firmware) | 1x | 60 |
+| **Integrated energy (Venus A only)** | `pv_energy_integrated`, `battery_energy_in_integrated`, `battery_energy_out_integrated` | kWh | Solar / charged / discharged energy accumulated from the derived powers (firmware counters are unusable on Venus A); survive restarts | 1x | 60 |
 | **Network** | `wifi_rssi` | dBm | Wi-Fi signal | 10x | 600 |
 |  | `wifi_ssid`, `wifi_ip`, `wifi_gateway`, `wifi_subnet`, `wifi_dns` | text | Wi-Fi configuration | 10x | 600 |
 | **Device info** | `device_model`, `firmware_version`, `ble_mac`, `wifi_mac`, `device_ip` | text | Identification fields | 10x | 600 |
@@ -279,8 +280,9 @@ solar. To feed the energy dashboard's battery section, create two
 - *Energy going in to the battery*: integrate `sensor.<device>_power_in` (method *Left*, unit prefix *k*)
 - *Energy coming out of the battery*: integrate `sensor.<device>_power_out` (method *Left*, unit prefix *k*)
 
-A third helper over `pv_power_es` gives solar production for the dashboard's
-solar section on Venus A.
+**Venus A needs no helpers**: the integration ships integrated counters —
+battery section: `battery_energy_in_integrated` / `battery_energy_out_integrated`,
+solar section: `pv_energy_integrated`.
 
 ## API maturity & known issues
 

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ After setup you can return to **Settings → Devices & Services → Marstek Loca
 |  | `ct_total_power` | W | CT aggregate | 5x | 300 |
 | **Mode** | `operating_mode` | text | Current mode (read-only sensor) | 5x | 300 |
 | **PV (Venus D only)** | `pv_power`, `pv_voltage`, `pv_current` | W / V / A | MPPT telemetry | 5x | 300 |
-| **PV strings (Venus A only)** | `pv1_power` … `pv4_power`, `pv1_voltage` … `pv4_voltage` | W / V | Per-string MPPT telemetry (string current omitted: unit is inconsistent on current firmware) | 1x | 60 |
+| **PV strings (Venus A only)** | `pv1_power` … `pv4_power`, `pv1_voltage` … `pv4_voltage` | W / V | Per-string MPPT telemetry. Firmware reports string power in different units per string; the integration resolves this against V×I (current omitted: integer-A resolution) | 1x | 60 |
 | **Integrated energy (Venus A only)** | `pv_energy_integrated`, `battery_energy_in_integrated`, `battery_energy_out_integrated` | kWh | Solar / charged / discharged energy accumulated from the derived powers (firmware counters are unusable on Venus A); survive restarts | 1x | 60 |
 | **Network** | `wifi_rssi` | dBm | Wi-Fi signal | 10x | 600 |
 |  | `wifi_ssid`, `wifi_ip`, `wifi_gateway`, `wifi_subnet`, `wifi_dns` | text | Wi-Fi configuration | 10x | 600 |
@@ -303,6 +303,7 @@ Venus A specifics (observed on firmware v148):
 - The device silently drops a large share of UDP requests (no error reply). The integration's retries usually get through, but occasional command timeouts and rejected writes (`set_result: false` while the device is busy) are normal — retry the service call.
 - `ES.GetStatus` does not include `bat_power` and always reports `pv_power`/`total_pv_energy` as 0. The integration derives battery power and solar power from `PV.GetStatus` and the grid flows instead.
 - `Bat.GetStatus` has no voltage/current/error-code fields, and `EM.GetStatus` has no `parse_state` — the corresponding entities are not created for Venus A.
+- `PV.GetStatus` reports string power in different units per string (observed: pv1 in deci-W, pv2 in plain W on the same response). The integration cross-checks each string against its voltage × current to pick the right unit.
 - The `wifi_mac` reported by the device can be the MAC of your access point rather than the battery's own WiFi module.
 
 Most of these issues are resolved by updating the device to the latest firmware — Marstek staggers rollouts, so many systems still run older versions. The Local API is evolving quickly and should stabilise as updates are deployed.

--- a/custom_components/marstek_local_api/compatibility.py
+++ b/custom_components/marstek_local_api/compatibility.py
@@ -27,6 +27,8 @@ HARDWARE VERSIONS:
 ------------------
 - HW 2.0: Original hardware (e.g., "VenusE")
 - HW 3.0: Newer hardware (e.g., "VenusE 3.0")
+- HW "A": Venus A ("Venus A"/"VenusA") — reports plain units (W/Wh/°C);
+  per-string PV power from PV.GetStatus is in deci-W
 
 All defaults are explicit in the matrix for maintainability.
 """
@@ -41,6 +43,7 @@ _LOGGER = logging.getLogger(__name__)
 # Hardware version detection
 HW_VERSION_2: Final = "2.0"
 HW_VERSION_3: Final = "3.0"
+HW_VERSION_VENUS_A: Final = "A"
 
 
 def parse_hardware_version(device_model: str) -> str:
@@ -50,9 +53,14 @@ def parse_hardware_version(device_model: str) -> str:
         "VenusE" -> "2.0"
         "VenusE 3.0" -> "3.0"
         "VenusD" -> "2.0"
+        "Venus A" -> "A"
     """
     if not device_model:
         return HW_VERSION_2
+
+    # Venus A reports plain units (W/Wh/°C) and needs its own matrix entries
+    if re.sub(r'\s+', '', device_model).lower().startswith("venusa"):
+        return HW_VERSION_VENUS_A
 
     # Check for explicit version in model name
     match = re.search(r'(\d+\.\d+)', device_model)
@@ -102,6 +110,7 @@ class CompatibilityMatrix:
             (HW_VERSION_2, 154): 0.1,    # FW 154+: raw value in deci-°C (÷0.1 = ×10)
             (HW_VERSION_3, 0): 1.0,      # FW 0+: raw value in °C
             (HW_VERSION_3, 139): 10.0,   # FW 0+: raw value in deca-°C (÷10)
+            (HW_VERSION_VENUS_A, 0): 1.0,  # Venus A: raw value in °C
         },
 
         # Battery capacity (Wh)
@@ -110,6 +119,7 @@ class CompatibilityMatrix:
             (HW_VERSION_2, 154): 1.0,    # FW 154+: raw value in Wh
             (HW_VERSION_3, 0): 1.0,      # FW 0+: raw value in Wh
             (HW_VERSION_3, 139): 0.1,      # FW 0+: raw value in deci-Wh (÷0.1)
+            (HW_VERSION_VENUS_A, 0): 1.0,  # Venus A: raw value in Wh
         },
 
         # Battery power (W)
@@ -117,6 +127,7 @@ class CompatibilityMatrix:
             (HW_VERSION_2, 0): 10.0,     # FW 0-153: raw value in deca-W (÷10)
             (HW_VERSION_2, 154): 1.0,    # FW 154+: raw value in W
             (HW_VERSION_3, 0): 1.0,      # FW 0+: raw value in W
+            (HW_VERSION_VENUS_A, 0): 1.0,  # Venus A: synthesized value in W
         },
 
         # Grid import energy (Wh)
@@ -124,6 +135,7 @@ class CompatibilityMatrix:
             (HW_VERSION_2, 0): 0.1,      # FW 0-153: raw × 10 = Wh (÷0.1)
             (HW_VERSION_2, 154): 0.01,   # FW 154+: raw × 100 = Wh (÷0.01)
             (HW_VERSION_3, 0): 1.0,      # FW 0+: raw value in Wh
+            (HW_VERSION_VENUS_A, 0): 1.0,  # Venus A: raw value in Wh
         },
 
         # Grid export energy (Wh)
@@ -131,6 +143,7 @@ class CompatibilityMatrix:
             (HW_VERSION_2, 0): 0.1,      # FW 0-153: raw × 10 = Wh (÷0.1)
             (HW_VERSION_2, 154): 0.01,   # FW 154+: raw × 100 = Wh (÷0.01)
             (HW_VERSION_3, 0): 1.0,      # FW 0+: raw value in Wh
+            (HW_VERSION_VENUS_A, 0): 1.0,  # Venus A: raw value in Wh
         },
 
         # Load energy (Wh)
@@ -138,6 +151,13 @@ class CompatibilityMatrix:
             (HW_VERSION_2, 0): 0.1,      # FW 0-153: raw × 10 = Wh (÷0.1)
             (HW_VERSION_2, 154): 0.01,   # FW 154+: raw × 100 = Wh (÷0.01)
             (HW_VERSION_3, 0): 1.0,      # FW 0+: raw value in Wh
+            (HW_VERSION_VENUS_A, 0): 1.0,  # Venus A: raw value in Wh
+        },
+
+        # Per-string PV power from PV.GetStatus (W)
+        # Venus A reports deci-W: pv1_power=3415 at 41V/8.3A (= 341.5 W)
+        "pv_string_power": {
+            (HW_VERSION_VENUS_A, 0): 10.0,
         },
 
         # Battery voltage (V) - ALWAYS scaled by 100

--- a/custom_components/marstek_local_api/config_flow.py
+++ b/custom_components/marstek_local_api/config_flow.py
@@ -8,13 +8,13 @@ from typing import Any
 import voluptuous as vol
 
 from homeassistant import config_entries
-from homeassistant.components import dhcp
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_HOST
 from homeassistant.core import HomeAssistant
-from homeassistant.data_entry_flow import FlowResult
+from homeassistant.data_entry_flow import AbortFlow, FlowResult
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import config_validation as cv
+from homeassistant.helpers.service_info.dhcp import DhcpServiceInfo
 
 from .api import MarstekAPIError, MarstekUDPClient
 from .const import CONF_PORT, DATA_COORDINATOR, DEFAULT_PORT, DEFAULT_SCAN_INTERVAL, DOMAIN
@@ -271,6 +271,10 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                     },
                 )
 
+            except AbortFlow:
+                # _abort_if_unique_id_configured() signals "already configured"
+                # by raising; it must not be treated as an error.
+                raise
             except CannotConnect:
                 errors["base"] = "cannot_connect"
             except Exception:  # pylint: disable=broad-except
@@ -284,7 +288,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         )
 
     async def async_step_dhcp(
-        self, discovery_info: dhcp.DhcpServiceInfo
+        self, discovery_info: DhcpServiceInfo
     ) -> FlowResult:
         """Handle DHCP discovery."""
         # Extract info from DHCP discovery
@@ -320,6 +324,11 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
             return await self.async_step_discovery_confirm()
 
+        except AbortFlow:
+            # _abort_if_unique_id_configured() signals "already configured"
+            # by raising; every DHCP lease renewal of a configured device
+            # lands here, so it must not be logged as an error.
+            raise
         except CannotConnect:
             return self.async_abort(reason="cannot_connect")
         except Exception:  # pylint: disable=broad-except

--- a/custom_components/marstek_local_api/const.py
+++ b/custom_components/marstek_local_api/const.py
@@ -59,6 +59,10 @@ ERROR_INVALID_PARAMS: Final = -32602
 ERROR_INTERNAL_ERROR: Final = -32603
 
 # Device models
+# NOTE: Venus A firmware reports "Venus A" (with a space) in Marstek.GetDevice,
+# so model checks must go through compatibility.parse_hardware_version()
+# rather than comparing against these constants directly.
+DEVICE_MODEL_VENUS_A: Final = "VenusA"
 DEVICE_MODEL_VENUS_C: Final = "VenusC"
 DEVICE_MODEL_VENUS_D: Final = "VenusD"
 DEVICE_MODEL_VENUS_E: Final = "VenusE"

--- a/custom_components/marstek_local_api/const.py
+++ b/custom_components/marstek_local_api/const.py
@@ -27,6 +27,11 @@ COMMAND_BACKOFF_FACTOR: Final = 2.0  # Multiplier for successive backoff delays
 COMMAND_BACKOFF_MAX: Final = 12.0  # Upper bound on backoff delay
 COMMAND_BACKOFF_JITTER: Final = 0.4  # Additional random jitter for backoff
 UNAVAILABLE_THRESHOLD: Final = 120  # Seconds before marking device unavailable
+# Circuit breaker: after this many consecutive update cycles without a single
+# response, reduce polling to one lightweight probe per cycle. Firmware whose
+# API task has wedged (observed on Venus A fw 148) can crash and lose its
+# settings when full retry barrages continue for hours.
+UNRESPONSIVE_CYCLE_THRESHOLD: Final = 3
 
 # API Methods
 METHOD_GET_DEVICE: Final = "Marstek.GetDevice"

--- a/custom_components/marstek_local_api/const.py
+++ b/custom_components/marstek_local_api/const.py
@@ -113,4 +113,4 @@ WEEKDAY_MAP: Final = {
     "sun": 64,  # 1000000
 }
 WEEKDAYS_ALL: Final = ["mon", "tue", "wed", "thu", "fri", "sat", "sun"]
-MAX_SCHEDULE_SLOTS: Final = 10  # Venus C/E supports slots 0-9
+MAX_SCHEDULE_SLOTS: Final = 10  # Venus C/E support slots 0-9 (verified on Venus A fw 148 as well)

--- a/custom_components/marstek_local_api/coordinator.py
+++ b/custom_components/marstek_local_api/coordinator.py
@@ -372,6 +372,27 @@ class MarstekDataUpdateCoordinator(DataUpdateCoordinator):
             return None
         return int(time.time() - self.last_message_timestamp)
 
+    def _category_poll_multiplier(self, category: str) -> int:
+        """Return the polling tier of a category in multiples of the base interval.
+
+        Must mirror the tiers in _async_update_data: em/mode (and pv on
+        Venus D) are only polled every UPDATE_INTERVAL_MEDIUM cycles, so
+        their staleness window has to be based on that cadence, not the
+        base update interval.
+        """
+        if category in ("es", "battery"):
+            return UPDATE_INTERVAL_FAST
+        if category in ("em", "mode"):
+            return UPDATE_INTERVAL_MEDIUM
+        if category == "pv":
+            # Venus A polls PV every fast cycle to derive battery power;
+            # computed dynamically because the model can change at runtime
+            # (_update_device_version).
+            if self.compatibility.hardware_version == HW_VERSION_VENUS_A:
+                return UPDATE_INTERVAL_FAST
+            return UPDATE_INTERVAL_MEDIUM
+        return 1
+
     def is_category_fresh(self, category: str) -> bool:
         """Check if category data is fresh enough to display.
 
@@ -393,8 +414,12 @@ class MarstekDataUpdateCoordinator(DataUpdateCoordinator):
         last_update = self.category_last_updated[category]
         elapsed = time.time() - last_update
 
-        # Calculate max age (update interval * threshold)
-        max_age = self.update_interval.total_seconds() * self.STALENESS_THRESHOLD
+        # Calculate max age (polling tier interval * threshold)
+        max_age = (
+            self.update_interval.total_seconds()
+            * self._category_poll_multiplier(category)
+            * self.STALENESS_THRESHOLD
+        )
 
         return elapsed < max_age
 

--- a/custom_components/marstek_local_api/coordinator.py
+++ b/custom_components/marstek_local_api/coordinator.py
@@ -28,6 +28,35 @@ from .const import (
 
 _LOGGER = logging.getLogger(__name__)
 
+# Minimum V*I (W) needed before it can arbitrate the string power unit;
+# below this the deci-W/W candidates are too close to tell apart.
+PV_STRING_UNIT_MIN_REFERENCE = 25.0
+
+
+def _scale_pv_string_power(
+    compatibility: CompatibilityMatrix, pv_status: dict, string: int
+) -> float | None:
+    """Return pv{string}_power in W, disambiguating the per-string unit.
+
+    Venus A firmware mixes power units BETWEEN strings of the same response
+    (observed live on fw 148: pv1 in deci-W, pv2 in plain W). String voltage
+    and current are plain V/A, so V*I picks the right interpretation whenever
+    it is large enough to discriminate; otherwise fall back to the
+    compatibility matrix scaling (a few W of error at most, at dawn/dusk).
+    """
+    raw = pv_status.get(f"pv{string}_power")
+    if not isinstance(raw, (int, float)):
+        return None
+    fallback = compatibility.scale_value(raw, "pv_string_power")
+    voltage = pv_status.get(f"pv{string}_voltage")
+    current = pv_status.get(f"pv{string}_current")
+    if not isinstance(voltage, (int, float)) or not isinstance(current, (int, float)):
+        return fallback
+    reference = voltage * current
+    if reference < PV_STRING_UNIT_MIN_REFERENCE:
+        return fallback
+    return min((raw / 10.0, float(raw)), key=lambda candidate: abs(candidate - reference))
+
 
 class MarstekMultiDeviceCoordinator(DataUpdateCoordinator):
     """Class to manage fetching data from multiple Marstek devices."""
@@ -538,8 +567,8 @@ class MarstekDataUpdateCoordinator(DataUpdateCoordinator):
                     for n in range(1, 5):
                         key = f"pv{n}_power"
                         if key in pv_status:
-                            pv_status[key] = self.compatibility.scale_value(
-                                pv_status[key], "pv_string_power"
+                            pv_status[key] = _scale_pv_string_power(
+                                self.compatibility, pv_status, n
                             )
                     data["pv"] = pv_status
                     self.category_last_updated["pv"] = time.time()

--- a/custom_components/marstek_local_api/coordinator.py
+++ b/custom_components/marstek_local_api/coordinator.py
@@ -20,6 +20,7 @@ from .const import (
     DEFAULT_SCAN_INTERVAL,
     DEVICE_MODEL_VENUS_D,
     UPDATE_INTERVAL_FAST,
+    UNRESPONSIVE_CYCLE_THRESHOLD,
     UPDATE_INTERVAL_MEDIUM,
     UPDATE_INTERVAL_SLOW,
     METHOD_BATTERY_STATUS,
@@ -303,6 +304,9 @@ class MarstekDataUpdateCoordinator(DataUpdateCoordinator):
         self._config_entry = config_entry
         self._device_mac = device_mac  # Used for multi-device mode to identify which device to update
 
+        # Circuit breaker state - consecutive cycles without any response
+        self._consecutive_failed_cycles = 0
+
         # Staleness tracking - track last successful update per category
         self.category_last_updated: dict[str, float] = {}
         self.STALENESS_THRESHOLD = 3  # missed updates before invalidation
@@ -503,6 +507,35 @@ class MarstekDataUpdateCoordinator(DataUpdateCoordinator):
             def _command_delay() -> float:
                 """Back off a little between calls; go faster while probing initial contact."""
                 return 0.2 if is_first_update and not had_success else 1.0
+
+            # Circuit breaker: when the device has answered nothing for several
+            # full cycles its API task is likely wedged. Keep probing with a
+            # single lightweight request per cycle instead of the full tiered
+            # poll with retries - wedged firmware (observed on Venus A fw 148)
+            # can crash and lose its settings under hours of retry pressure.
+            if (
+                not is_first_update
+                and self._consecutive_failed_cycles >= UNRESPONSIVE_CYCLE_THRESHOLD
+            ):
+                try:
+                    await asyncio.sleep(_command_delay())
+                    probe = await self.api.get_es_status(timeout=5, max_attempts=1)
+                except Exception:
+                    probe = None
+                if not probe:
+                    self._consecutive_failed_cycles += 1
+                    if self._consecutive_failed_cycles % 10 == 0:
+                        _LOGGER.warning(
+                            "Device unresponsive for %d polling cycles; polling stays "
+                            "reduced to one probe per cycle",
+                            self._consecutive_failed_cycles,
+                        )
+                    return data
+                _LOGGER.info(
+                    "Device answering again after %d unresponsive cycles; resuming normal polling",
+                    self._consecutive_failed_cycles,
+                )
+                self._consecutive_failed_cycles = 0
 
             if is_first_update:
                 _LOGGER.debug("First update - fetching device info")
@@ -709,6 +742,19 @@ class MarstekDataUpdateCoordinator(DataUpdateCoordinator):
                 _LOGGER.warning(
                     "First update did not receive any data from device; continuing setup and retrying in background"
                 )
+
+            # Track consecutive all-failed cycles for the circuit breaker
+            if had_success:
+                self._consecutive_failed_cycles = 0
+            else:
+                self._consecutive_failed_cycles += 1
+                if self._consecutive_failed_cycles == UNRESPONSIVE_CYCLE_THRESHOLD:
+                    _LOGGER.warning(
+                        "No response to any command for %d consecutive cycles; "
+                        "reducing polling to one probe per cycle to avoid "
+                        "pressuring the device",
+                        self._consecutive_failed_cycles,
+                    )
 
             # If we got any new data, update the last message timestamp
             # (We compare with the preserved old data to see if anything changed)

--- a/custom_components/marstek_local_api/coordinator.py
+++ b/custom_components/marstek_local_api/coordinator.py
@@ -13,7 +13,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
 from .api import MarstekAPIError, MarstekUDPClient
-from .compatibility import CompatibilityMatrix
+from .compatibility import CompatibilityMatrix, HW_VERSION_VENUS_A
 from .const import (
     COMMAND_MAX_ATTEMPTS,
     COMMAND_TIMEOUT,
@@ -494,6 +494,53 @@ class MarstekDataUpdateCoordinator(DataUpdateCoordinator):
                 data["es"] = es_status
                 self.category_last_updated["es"] = time.time()
                 had_success = True
+
+            # Venus A firmware always reports pv_power=0 in ES.GetStatus and omits
+            # bat_power entirely. Poll the PV strings every update and derive both
+            # fields so the power/state/solar sensors work on this model.
+            if es_status and self.compatibility.hardware_version == HW_VERSION_VENUS_A:
+                try:
+                    await asyncio.sleep(_command_delay())  # Delay between API calls
+                    pv_status = await self.api.get_pv_status(**_command_kwargs())
+                except Exception as err:
+                    _LOGGER.debug("Failed to get PV status: %s", err)
+                    pv_status = None
+
+                if pv_status:
+                    # Scale per-string power at receipt (same pattern as the
+                    # battery_status fields below) so sensors and the stale
+                    # fallback path always see final W values.
+                    for n in range(1, 5):
+                        key = f"pv{n}_power"
+                        if key in pv_status:
+                            pv_status[key] = self.compatibility.scale_value(
+                                pv_status[key], "pv_string_power"
+                            )
+                    data["pv"] = pv_status
+                    self.category_last_updated["pv"] = time.time()
+                    had_success = True
+                else:
+                    # Venus A silently drops a large share of requests;
+                    # fall back to the last known (already scaled) string data
+                    pv_status = data.get("pv")
+
+                if pv_status:
+                    known_powers = []
+                    for n in range(1, 5):
+                        string_power = pv_status.get(f"pv{n}_power")
+                        if isinstance(string_power, (int, float)):
+                            known_powers.append(string_power)
+                    if known_powers:
+                        es_status["pv_power"] = sum(known_powers)
+
+                if "bat_power" not in es_status:
+                    ongrid_power = es_status.get("ongrid_power")
+                    if ongrid_power is not None:
+                        pv_power = es_status.get("pv_power") or 0
+                        offgrid_power = es_status.get("offgrid_power") or 0
+                        # Charging positive: PV and grid import feed the battery,
+                        # on-/off-grid output drains it (ongrid is negative on import)
+                        es_status["bat_power"] = pv_power - ongrid_power - offgrid_power
 
             try:
                 await asyncio.sleep(_command_delay())  # Delay between API calls

--- a/custom_components/marstek_local_api/diagnostics.py
+++ b/custom_components/marstek_local_api/diagnostics.py
@@ -76,6 +76,9 @@ def _coordinator_snapshot(coordinator: MarstekDataUpdateCoordinator) -> dict[str
         # Command compatibility matrix
         "command_compatibility": command_stats,
         "compatibility_summary": compatibility_summary,
+
+        # Selected scaling profile (hardware/firmware detection)
+        "compatibility": coordinator.compatibility.get_info(),
     }
 
     return async_redact_data(snapshot, TO_REDACT)

--- a/custom_components/marstek_local_api/manifest.json
+++ b/custom_components/marstek_local_api/manifest.json
@@ -8,6 +8,9 @@
   "dhcp": [
     {
       "macaddress": "60CF84*"
+    },
+    {
+      "macaddress": "2CF8EC*"
     }
   ],
   "documentation": "https://github.com/jaapp/ha-marstek-local-api",

--- a/custom_components/marstek_local_api/sensor.py
+++ b/custom_components/marstek_local_api/sensor.py
@@ -4,8 +4,10 @@ from __future__ import annotations
 from collections.abc import Callable
 from dataclasses import dataclass, replace
 import logging
+import time
 
 from homeassistant.components.sensor import (
+    RestoreSensor,
     SensorDeviceClass,
     SensorEntity,
     SensorEntityDescription,
@@ -454,6 +456,65 @@ VENUS_A_ZERO_COUNTER_KEYS = {
 }
 
 
+class EnergyIntegrator:
+    """Accumulate energy (Wh) from periodic power samples (left Riemann sum).
+
+    Gaps longer than max_gap_seconds (missed polls, restarts) and samples
+    without a power value are not accumulated.
+    """
+
+    def __init__(self, max_gap_seconds: float) -> None:
+        self._max_gap = max_gap_seconds
+        self._last_power: float | None = None
+        self._last_ts: float | None = None
+        self.energy_wh: float = 0.0
+
+    def add_sample(self, power_w: float | None, timestamp: float) -> float:
+        """Add a power sample and return the accumulated energy in Wh."""
+        if self._last_power is not None and self._last_ts is not None:
+            elapsed = timestamp - self._last_ts
+            if 0 < elapsed <= self._max_gap:
+                self.energy_wh += self._last_power * elapsed / 3600.0
+        self._last_power = power_w if isinstance(power_w, (int, float)) else None
+        self._last_ts = timestamp
+        return self.energy_wh
+
+
+# Venus A firmware hardcodes total_pv_energy to 0, and its grid counters miss
+# energy charged from the MPPT inputs, so solar and battery charge/discharge
+# energy are accumulated from the derived powers instead (persisted via
+# RestoreSensor). These feed the energy dashboard's solar and battery sections.
+INTEGRATED_ENERGY_SENSOR_TYPES: tuple[MarstekSensorEntityDescription, ...] = (
+    MarstekSensorEntityDescription(
+        key="pv_energy_integrated",
+        name="Integrated solar energy",
+        native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
+        device_class=SensorDeviceClass.ENERGY,
+        state_class=SensorStateClass.TOTAL_INCREASING,
+        value_fn=lambda data: data.get("es", {}).get("pv_power"),
+        category="es",
+    ),
+    MarstekSensorEntityDescription(
+        key="battery_energy_in_integrated",
+        name="Integrated charged energy",
+        native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
+        device_class=SensorDeviceClass.ENERGY,
+        state_class=SensorStateClass.TOTAL_INCREASING,
+        value_fn=lambda data: max(0, data.get("es", {}).get("bat_power", 0) or 0),
+        category="es",
+    ),
+    MarstekSensorEntityDescription(
+        key="battery_energy_out_integrated",
+        name="Integrated discharged energy",
+        native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
+        device_class=SensorDeviceClass.ENERGY,
+        state_class=SensorStateClass.TOTAL_INCREASING,
+        value_fn=lambda data: max(0, -(data.get("es", {}).get("bat_power", 0) or 0)),
+        category="es",
+    ),
+)
+
+
 def _standard_sensor_types(
     coordinator: MarstekDataUpdateCoordinator,
 ) -> tuple[MarstekSensorEntityDescription, ...]:
@@ -660,6 +721,17 @@ async def async_setup_entry(
                             device_data=device_data,
                         )
                     )
+                # Venus A firmware has no usable energy counters - integrate them
+                for description in INTEGRATED_ENERGY_SENSOR_TYPES:
+                    entities.append(
+                        MarstekMultiDeviceIntegratedEnergySensor(
+                            coordinator=coordinator,
+                            device_coordinator=device_coordinator,
+                            entity_description=description,
+                            device_mac=mac,
+                            device_data=device_data,
+                        )
+                    )
 
         # Add aggregate/system sensors
         # Create a synthetic unique ID for the system device
@@ -708,6 +780,15 @@ async def async_setup_entry(
                         entry=entry,
                     )
                 )
+            # Venus A firmware has no usable energy counters - integrate them
+            for description in INTEGRATED_ENERGY_SENSOR_TYPES:
+                entities.append(
+                    MarstekIntegratedEnergySensor(
+                        coordinator=coordinator,
+                        entity_description=description,
+                        entry=entry,
+                    )
+                )
 
     async_add_entities(entities)
 
@@ -740,6 +821,10 @@ class MarstekSensor(CoordinatorEntity, SensorEntity):
     @property
     def native_value(self):
         """Return the state of the sensor."""
+        return self._fresh_value()
+
+    def _fresh_value(self):
+        """Return the described value, or None while its category is stale."""
         if not self.entity_description.value_fn:
             return None
 
@@ -794,6 +879,10 @@ class MarstekMultiDeviceSensor(CoordinatorEntity, SensorEntity):
     @property
     def native_value(self):
         """Return the state of the sensor."""
+        return self._fresh_value()
+
+    def _fresh_value(self):
+        """Return the described value, or None while its category is stale."""
         if not self.entity_description.value_fn:
             return None
 
@@ -855,3 +944,59 @@ class MarstekAggregateSensor(CoordinatorEntity, SensorEntity):
         # Keep entity available if we have any aggregate data (prevents "unknown" on transient failures)
         aggregates = self.coordinator.data.get("aggregates", {})
         return aggregates is not None and len(aggregates) > 0
+
+
+class MarstekIntegratedEnergyMixin(RestoreSensor):
+    """Accumulate a power reading into a persistent energy total.
+
+    Concrete classes must set self._integrator and provide _fresh_value()
+    returning the current source power in W (or None while stale).
+    """
+
+    _integrator: EnergyIntegrator
+
+    async def async_added_to_hass(self) -> None:
+        """Restore the accumulated total from the previous run."""
+        await super().async_added_to_hass()
+        last = await self.async_get_last_sensor_data()
+        if last is not None and last.native_value is not None:
+            try:
+                self._integrator.energy_wh = float(last.native_value) * 1000.0
+            except (TypeError, ValueError):
+                pass
+
+    def _handle_coordinator_update(self) -> None:
+        """Integrate the source power on every coordinator update."""
+        self._integrator.add_sample(self._fresh_value(), time.time())
+        super()._handle_coordinator_update()
+
+    @property
+    def native_value(self):
+        """Return the accumulated energy in kWh."""
+        return round(self._integrator.energy_wh / 1000.0, 3)
+
+
+class MarstekIntegratedEnergySensor(MarstekIntegratedEnergyMixin, MarstekSensor):
+    """Integrated energy sensor (single-device mode)."""
+
+    def __init__(self, coordinator, entity_description, entry) -> None:
+        """Initialize the sensor."""
+        super().__init__(coordinator, entity_description, entry)
+        max_gap = coordinator.update_interval.total_seconds() * 3
+        self._integrator = EnergyIntegrator(max_gap)
+
+
+class MarstekMultiDeviceIntegratedEnergySensor(
+    MarstekIntegratedEnergyMixin, MarstekMultiDeviceSensor
+):
+    """Integrated energy sensor (multi-device mode)."""
+
+    def __init__(
+        self, coordinator, device_coordinator, entity_description, device_mac, device_data
+    ) -> None:
+        """Initialize the sensor."""
+        super().__init__(
+            coordinator, device_coordinator, entity_description, device_mac, device_data
+        )
+        max_gap = device_coordinator.update_interval.total_seconds() * 3
+        self._integrator = EnergyIntegrator(max_gap)

--- a/custom_components/marstek_local_api/sensor.py
+++ b/custom_components/marstek_local_api/sensor.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 from collections.abc import Callable
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 import logging
 
 from homeassistant.components.sensor import (
@@ -26,6 +26,7 @@ from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
+from .compatibility import HW_VERSION_VENUS_A
 from .const import DATA_COORDINATOR, DEVICE_MODEL_VENUS_D, DOMAIN
 from .coordinator import MarstekDataUpdateCoordinator, MarstekMultiDeviceCoordinator
 
@@ -406,6 +407,70 @@ PV_SENSOR_TYPES: tuple[MarstekSensorEntityDescription, ...] = (
     ),
 )
 
+# Per-string PV sensors (Venus A reports pv1..pv4_power/_voltage in
+# PV.GetStatus instead of the single pv_power/pv_voltage of Venus D).
+# String current is intentionally omitted: the unit reported by live
+# Venus A hardware is inconsistent between strings.
+PV_STRING_SENSOR_TYPES: tuple[MarstekSensorEntityDescription, ...] = tuple(
+    description
+    for string in range(1, 5)
+    for description in (
+        MarstekSensorEntityDescription(
+            key=f"pv{string}_power",
+            name=f"PV string {string} power",
+            native_unit_of_measurement=UnitOfPower.WATT,
+            device_class=SensorDeviceClass.POWER,
+            state_class=SensorStateClass.MEASUREMENT,
+            value_fn=lambda data, key=f"pv{string}_power": data.get("pv", {}).get(key),
+            category="pv",
+        ),
+        MarstekSensorEntityDescription(
+            key=f"pv{string}_voltage",
+            name=f"PV string {string} voltage",
+            native_unit_of_measurement=UnitOfElectricPotential.VOLT,
+            device_class=SensorDeviceClass.VOLTAGE,
+            state_class=SensorStateClass.MEASUREMENT,
+            value_fn=lambda data, key=f"pv{string}_voltage": data.get("pv", {}).get(key),
+            category="pv",
+        ),
+    )
+)
+
+# Fields Venus A firmware never includes in its responses (no
+# bat_voltage/bat_current/error_code in Bat.GetStatus, no parse_state in
+# EM.GetStatus) - creating these sensors would leave them permanently unknown.
+VENUS_A_UNSUPPORTED_KEYS = {
+    "battery_voltage",
+    "battery_current",
+    "battery_error_code",
+    "ct_parse_state",
+}
+
+# Energy counters Venus A firmware hardcodes to 0. Created disabled by
+# default so they stay discoverable in case a firmware update fixes them.
+VENUS_A_ZERO_COUNTER_KEYS = {
+    "total_pv_energy",
+    "total_load_energy",
+}
+
+
+def _standard_sensor_types(
+    coordinator: MarstekDataUpdateCoordinator,
+) -> tuple[MarstekSensorEntityDescription, ...]:
+    """Return SENSOR_TYPES adjusted for the device model."""
+    if coordinator.compatibility.hardware_version != HW_VERSION_VENUS_A:
+        return SENSOR_TYPES
+
+    descriptions = []
+    for description in SENSOR_TYPES:
+        if description.key in VENUS_A_UNSUPPORTED_KEYS:
+            continue
+        if description.key in VENUS_A_ZERO_COUNTER_KEYS:
+            description = replace(description, entity_registry_enabled_default=False)
+        descriptions.append(description)
+    return tuple(descriptions)
+
+
 # Aggregate sensors (multi-device only)
 AGGREGATE_SENSOR_TYPES: tuple[MarstekSensorEntityDescription, ...] = (
     MarstekSensorEntityDescription(
@@ -560,7 +625,7 @@ async def async_setup_entry(
             device_data = next(d for d in coordinator.devices if (d.get("ble_mac") or d.get("wifi_mac")) == mac)
 
             # Add standard sensors for this device
-            for description in SENSOR_TYPES:
+            for description in _standard_sensor_types(device_coordinator):
                 entities.append(
                     MarstekMultiDeviceSensor(
                         coordinator=coordinator,
@@ -574,6 +639,18 @@ async def async_setup_entry(
             # Add PV sensors if Venus D
             if device_coordinator.device_model == DEVICE_MODEL_VENUS_D:
                 for description in PV_SENSOR_TYPES:
+                    entities.append(
+                        MarstekMultiDeviceSensor(
+                            coordinator=coordinator,
+                            device_coordinator=device_coordinator,
+                            entity_description=description,
+                            device_mac=mac,
+                            device_data=device_data,
+                        )
+                    )
+            # Venus A reports per-string PV data instead
+            elif device_coordinator.compatibility.hardware_version == HW_VERSION_VENUS_A:
+                for description in PV_STRING_SENSOR_TYPES:
                     entities.append(
                         MarstekMultiDeviceSensor(
                             coordinator=coordinator,
@@ -602,7 +679,7 @@ async def async_setup_entry(
     else:
         # Single device mode (legacy)
         # Add standard sensors
-        for description in SENSOR_TYPES:
+        for description in _standard_sensor_types(coordinator):
             entities.append(
                 MarstekSensor(
                     coordinator=coordinator,
@@ -614,6 +691,16 @@ async def async_setup_entry(
         # Add PV sensors if Venus D
         if coordinator.device_model == DEVICE_MODEL_VENUS_D:
             for description in PV_SENSOR_TYPES:
+                entities.append(
+                    MarstekSensor(
+                        coordinator=coordinator,
+                        entity_description=description,
+                        entry=entry,
+                    )
+                )
+        # Venus A reports per-string PV data instead
+        elif coordinator.compatibility.hardware_version == HW_VERSION_VENUS_A:
+            for description in PV_STRING_SENSOR_TYPES:
                 entities.append(
                     MarstekSensor(
                         coordinator=coordinator,

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -134,9 +134,9 @@ Venus A response (per string, observed on fw 148):
 
 | Field | Type | Sensor | Description |
 |-------|------|--------|-------------|
-| pv1_power … pv4_power | number | ✅ Sensor | String power in **deci-W** (scaled ÷10 by the compatibility matrix) |
+| pv1_power … pv4_power | number | ✅ Sensor | String power — **unit differs per string** (fw 148: pv1 deci-W, pv2 plain W). The coordinator disambiguates each string against V×I (`_scale_pv_string_power`), falling back to the matrix ÷10 when V×I is too small to discriminate |
 | pv1_voltage … pv4_voltage | number | ✅ Sensor | String voltage (V) |
-| pv1_current … pv4_current | number | ❌ | Unit inconsistent between strings on current firmware — not exposed |
+| pv1_current … pv4_current | number | ❌ | String current, plain A truncated to integer (1 A resolution) — too coarse to expose |
 | pv1_state … pv4_state | number | ❌ | 1 = string active, 0 = inactive |
 
 On Venus A the coordinator polls PV on the fast tier (every update): the string
@@ -438,8 +438,9 @@ Options:
 | Venus D | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
 | Venus A | ✅ | ✅ | ✅ | ✅ (no voltage/current/error_code) | ✅ (per string) | ✅ (no bat_power; pv/load energy always 0) | ✅ (no parse_state) |
 
-Venus A reports plain units (W / Wh / °C) for every field; its per-string PV
-power is deci-W. See the `"A"` hardware profile in `compatibility.py`.
+Venus A reports plain units (W / Wh / °C) for every field except per-string PV
+power, whose unit differs per string and is disambiguated against V×I. See the
+`"A"` hardware profile in `compatibility.py` and `_scale_pv_string_power`.
 
 ---
 

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -2,10 +2,10 @@
 
 ## Overview
 
-Home Assistant integration for Marstek energy storage systems using the official Local API (Rev 1.0). Provides comprehensive monitoring and control of Marstek Venus C/D/E devices without requiring cloud connectivity or additional hardware.
+Home Assistant integration for Marstek energy storage systems using the official Local API (Rev 1.0). Provides comprehensive monitoring and control of Marstek Venus A/C/D/E devices without requiring cloud connectivity or additional hardware.
 
 **Version:** 1.0
-**Target Devices:** Venus C, Venus D, Venus E
+**Target Devices:** Venus A, Venus C, Venus D, Venus E
 **Protocol:** JSON over UDP (port 30000+)
 **Requirements:** Local API enabled in Marstek app
 
@@ -119,14 +119,30 @@ marstek_local_api/
 - Available Capacity: `(100 - SOC) × rated_capacity / 100` (Wh)
 - Battery State: `charging` / `discharging` / `idle` (based on bat_power)
 
-### 3.5 PV (Photovoltaic) - Venus D Only
+### 3.5 PV (Photovoltaic) - Venus D and Venus A
 **Method:** `PV.GetStatus`
+
+Venus D response (single MPPT summary):
 
 | Field | Type | Sensor | Description |
 |-------|------|--------|-------------|
 | pv_power | number | ✅ Sensor | Solar charging power (W) |
 | pv_voltage | number | ✅ Sensor | Solar voltage (V) |
 | pv_current | number | ✅ Sensor | Solar current (A) |
+
+Venus A response (per string, observed on fw 148):
+
+| Field | Type | Sensor | Description |
+|-------|------|--------|-------------|
+| pv1_power … pv4_power | number | ✅ Sensor | String power in **deci-W** (scaled ÷10 by the compatibility matrix) |
+| pv1_voltage … pv4_voltage | number | ✅ Sensor | String voltage (V) |
+| pv1_current … pv4_current | number | ❌ | Unit inconsistent between strings on current firmware — not exposed |
+| pv1_state … pv4_state | number | ❌ | 1 = string active, 0 = inactive |
+
+On Venus A the coordinator polls PV on the fast tier (every update): the string
+sum replaces the always-zero `es.pv_power`, and battery power is derived as
+`pv_power - ongrid_power - offgrid_power` because `ES.GetStatus` omits
+`bat_power` on this model.
 
 ### 3.6 ES (Energy System)
 **Method:** `ES.GetStatus`
@@ -420,6 +436,10 @@ Options:
 | Venus C | ✅ | ✅ | ✅ | ✅ | ❌ | ✅ | ✅ |
 | Venus E | ✅ | ✅ | ✅ | ✅ | ❌ | ✅ | ✅ |
 | Venus D | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| Venus A | ✅ | ✅ | ✅ | ✅ (no voltage/current/error_code) | ✅ (per string) | ✅ (no bat_power; pv/load energy always 0) | ✅ (no parse_state) |
+
+Venus A reports plain units (W / Wh / °C) for every field; its per-string PV
+power is deci-W. See the `"A"` hardware profile in `compatibility.py`.
 
 ---
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+testpaths = tests
+asyncio_mode = auto

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,0 +1,1 @@
+pytest-homeassistant-custom-component

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the Marstek Local API integration."""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,8 @@
+"""Shared fixtures for marstek_local_api tests."""
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def auto_enable_custom_integrations(enable_custom_integrations):
+    """Enable loading custom integrations in all tests."""
+    yield

--- a/tests/test_compatibility.py
+++ b/tests/test_compatibility.py
@@ -1,0 +1,108 @@
+"""Tests for the version/hardware compatibility matrix."""
+import pytest
+
+from custom_components.marstek_local_api.compatibility import (
+    HW_VERSION_2,
+    HW_VERSION_3,
+    HW_VERSION_VENUS_A,
+    CompatibilityMatrix,
+    get_base_model,
+    parse_hardware_version,
+)
+
+
+@pytest.mark.parametrize(
+    ("device_model", "expected"),
+    [
+        ("VenusE", HW_VERSION_2),
+        ("VenusC", HW_VERSION_2),
+        ("VenusD", HW_VERSION_2),
+        ("VenusE 3.0", HW_VERSION_3),
+        ("Venus A", HW_VERSION_VENUS_A),
+        ("VenusA", HW_VERSION_VENUS_A),
+        ("venus a", HW_VERSION_VENUS_A),
+        ("", HW_VERSION_2),
+    ],
+)
+def test_parse_hardware_version(device_model, expected):
+    """Model strings map to the right hardware profile."""
+    assert parse_hardware_version(device_model) == expected
+
+
+def test_get_base_model_strips_version_suffix():
+    assert get_base_model("VenusE 3.0") == "VenusE"
+    assert get_base_model("VenusE") == "VenusE"
+    assert get_base_model("") == ""
+
+
+class TestVenusAScaling:
+    """Venus A (fw 148) reports plain units; nothing should be rescaled."""
+
+    matrix = CompatibilityMatrix("Venus A", 148)
+
+    def test_hardware_detection(self):
+        assert self.matrix.hardware_version == HW_VERSION_VENUS_A
+
+    @pytest.mark.parametrize(
+        ("field", "raw", "expected"),
+        [
+            ("bat_temp", 34.0, 34.0),
+            ("bat_capacity", 1285.0, 1285.0),
+            ("bat_power", 812, 812.0),
+            ("total_grid_input_energy", 21229, 21229.0),
+            ("total_grid_output_energy", 15054, 15054.0),
+            ("total_load_energy", 0, 0.0),
+        ],
+    )
+    def test_plain_units(self, field, raw, expected):
+        assert self.matrix.scale_value(raw, field) == expected
+
+    def test_pv_string_power_is_deci_watts(self):
+        # Observed live: raw 3415 at 41 V / ~8.3 A -> 341.5 W
+        assert self.matrix.scale_value(3415, "pv_string_power") == 341.5
+
+    def test_unknown_field_passthrough(self):
+        assert self.matrix.scale_value(123, "ongrid_power") == 123
+
+    def test_none_passthrough(self):
+        assert self.matrix.scale_value(None, "bat_temp") is None
+
+
+class TestVenus2Scaling:
+    """HW 2.0 profiles must be unaffected by the Venus A additions."""
+
+    def test_old_firmware_energy_is_deca_wh(self):
+        matrix = CompatibilityMatrix("VenusE", 153)
+        assert matrix.scale_value(100, "total_grid_input_energy") == 1000.0
+
+    def test_new_firmware_energy_is_centi_wh(self):
+        matrix = CompatibilityMatrix("VenusE", 154)
+        assert matrix.scale_value(100, "total_grid_input_energy") == 10000.0
+
+    def test_old_firmware_bat_power_is_deca_w(self):
+        matrix = CompatibilityMatrix("VenusE", 100)
+        assert matrix.scale_value(100, "bat_power") == 10.0
+
+    def test_new_firmware_bat_temp_times_ten(self):
+        # (HW2, 154) divisor is 0.1, i.e. raw x 10 (upstream behavior, PR #32)
+        matrix = CompatibilityMatrix("VenusE", 154)
+        assert matrix.scale_value(3.45, "bat_temp") == pytest.approx(34.5)
+
+    def test_pv_string_power_not_scaled_for_hw2(self):
+        # No HW 2.0 entry exists for pv_string_power -> raw passthrough
+        matrix = CompatibilityMatrix("VenusD", 154)
+        assert matrix.scale_value(341, "pv_string_power") == 341
+
+
+class TestVenus3Scaling:
+    def test_temp_deca_c_from_fw139(self):
+        matrix = CompatibilityMatrix("VenusE 3.0", 139)
+        assert matrix.scale_value(340, "bat_temp") == 34.0
+
+    def test_capacity_deci_wh_from_fw139(self):
+        matrix = CompatibilityMatrix("VenusE 3.0", 139)
+        assert matrix.scale_value(100, "bat_capacity") == 1000.0
+
+    def test_energy_plain_wh(self):
+        matrix = CompatibilityMatrix("VenusE 3.0", 139)
+        assert matrix.scale_value(21229, "total_grid_input_energy") == 21229.0

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -1,0 +1,101 @@
+"""Tests for config-flow abort paths (already-configured devices)."""
+from unittest.mock import AsyncMock, patch
+
+from homeassistant import config_entries
+from homeassistant.const import CONF_HOST
+from homeassistant.data_entry_flow import FlowResultType
+
+try:
+    from homeassistant.helpers.service_info.dhcp import DhcpServiceInfo
+except ImportError:  # pragma: no cover - older cores
+    from homeassistant.components.dhcp import DhcpServiceInfo
+
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.marstek_local_api.const import CONF_PORT, DOMAIN
+
+DEVICE_INFO = {
+    "title": "Venus A",
+    "device": "Venus A",
+    "firmware": 148,
+    "ble_mac": "2cf8ec203003",
+    "wifi_mac": "dc396f386c87",
+}
+
+
+def existing_entry(host="192.168.178.50"):
+    return MockConfigEntry(
+        domain=DOMAIN,
+        unique_id=DEVICE_INFO["ble_mac"],
+        data={
+            CONF_HOST: host,
+            CONF_PORT: 30000,
+            "ble_mac": DEVICE_INFO["ble_mac"],
+            "wifi_mac": DEVICE_INFO["wifi_mac"],
+            "device": DEVICE_INFO["device"],
+            "firmware": DEVICE_INFO["firmware"],
+        },
+    )
+
+
+def patch_validate_input():
+    return patch(
+        "custom_components.marstek_local_api.config_flow.validate_input",
+        new=AsyncMock(return_value=dict(DEVICE_INFO)),
+    )
+
+
+def dhcp_renewal(ip="192.168.178.104"):
+    return DhcpServiceInfo(ip=ip, hostname="venus", macaddress="2cf8ec205731")
+
+
+async def test_dhcp_rediscovery_aborts_already_configured(hass):
+    """A DHCP lease renewal of a configured device aborts cleanly, updating the host.
+
+    Regression: AbortFlow raised by _abort_if_unique_id_configured() was caught
+    by the broad exception handler and logged as an ERROR on every renewal.
+    """
+    entry = existing_entry(host="192.168.178.50")
+    entry.add_to_hass(hass)
+
+    with patch_validate_input():
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": config_entries.SOURCE_DHCP},
+            data=dhcp_renewal(ip="192.168.178.104"),
+        )
+
+    assert result["type"] == FlowResultType.ABORT
+    assert result["reason"] == "already_configured"
+    assert entry.data[CONF_HOST] == "192.168.178.104"
+
+
+async def test_dhcp_discovery_new_device_asks_confirmation(hass):
+    with patch_validate_input():
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": config_entries.SOURCE_DHCP},
+            data=dhcp_renewal(),
+        )
+
+    assert result["type"] == FlowResultType.FORM
+    assert result["step_id"] == "discovery_confirm"
+
+
+async def test_manual_setup_aborts_already_configured(hass):
+    """Manually re-adding a configured device aborts instead of showing 'unknown'."""
+    entry = existing_entry()
+    entry.add_to_hass(hass)
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": "manual"}
+    )
+    assert result["type"] == FlowResultType.FORM
+
+    with patch_validate_input():
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], {CONF_HOST: "192.168.178.50", CONF_PORT: 30000}
+        )
+
+    assert result["type"] == FlowResultType.ABORT
+    assert result["reason"] == "already_configured"

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -1,0 +1,199 @@
+"""Tests for the Venus A data derivation and staleness logic in the coordinator."""
+import time
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from custom_components.marstek_local_api.coordinator import (
+    MarstekDataUpdateCoordinator,
+)
+
+VENUS_A_DEVICE = {
+    "device": "Venus A",
+    "ver": 148,
+    "ble_mac": "2cf8ec203003",
+    "wifi_mac": "dc396f386c87",
+    "ip": "192.168.178.104",
+}
+
+# Venus A firmware omits bat_power and hardcodes pv_power/total_pv_energy to 0
+def venus_a_es_status(ongrid=-812):
+    return {
+        "id": 0,
+        "bat_soc": 63,
+        "bat_cap": 2080,
+        "pv_power": 0,
+        "ongrid_power": ongrid,
+        "offgrid_power": 0,
+        "total_pv_energy": 0,
+        "total_grid_output_energy": 15054,
+        "total_grid_input_energy": 21229,
+        "total_load_energy": 0,
+    }
+
+
+def venus_a_pv_status():
+    # Raw per-string power in deci-W as returned by fw 148
+    return {
+        "id": 0,
+        "pv1_power": 3415, "pv1_voltage": 41, "pv1_current": 8, "pv1_state": 1,
+        "pv2_power": 131, "pv2_voltage": 42, "pv2_current": 3, "pv2_state": 1,
+        "pv3_power": 0, "pv3_voltage": 1, "pv3_current": 0, "pv3_state": 0,
+        "pv4_power": 0, "pv4_voltage": 0, "pv4_current": 0, "pv4_state": 0,
+    }
+
+
+def venus_a_battery_status():
+    return {
+        "id": 0,
+        "soc": 63,
+        "charg_flag": True,
+        "dischrg_flag": True,
+        "bat_temp": 34.0,
+        "bat_capacity": 1285.0,
+        "rated_capacity": 2080.0,
+    }
+
+
+def make_api(model="Venus A", firmware=148, es=None, pv_side_effect=None):
+    api = MagicMock()
+    api.get_device_info = AsyncMock(
+        return_value=dict(VENUS_A_DEVICE, device=model, ver=firmware)
+    )
+    api.get_es_status = AsyncMock(side_effect=lambda **kw: dict(es or venus_a_es_status()))
+    api.get_battery_status = AsyncMock(side_effect=lambda **kw: dict(venus_a_battery_status()))
+    api.get_pv_status = AsyncMock(
+        side_effect=pv_side_effect or (lambda **kw: dict(venus_a_pv_status()))
+    )
+    api.get_em_status = AsyncMock(return_value=None)
+    api.get_es_mode = AsyncMock(return_value=None)
+    api.get_wifi_status = AsyncMock(return_value=None)
+    api.get_ble_status = AsyncMock(return_value=None)
+    return api
+
+
+def make_coordinator(hass, api, model="Venus A", firmware=148):
+    return MarstekDataUpdateCoordinator(
+        hass,
+        api=api,
+        device_name="Test Battery",
+        firmware_version=firmware,
+        device_model=model,
+        scan_interval=60,
+    )
+
+
+@pytest.fixture(autouse=True)
+def fast_sleep():
+    """Skip the inter-command delays in the polling loop."""
+    with patch(
+        "custom_components.marstek_local_api.coordinator.asyncio.sleep",
+        new=AsyncMock(),
+    ):
+        yield
+
+
+async def test_venus_a_derives_pv_and_battery_power(hass):
+    """pv_power = scaled string sum; bat_power = pv - ongrid - offgrid."""
+    api = make_api()
+    coordinator = make_coordinator(hass, api)
+
+    data = await coordinator._async_update_data()
+
+    # Per-string power scaled from deci-W at receipt
+    assert data["pv"]["pv1_power"] == 341.5
+    assert data["pv"]["pv2_power"] == 13.1
+    # es.pv_power replaced by the string sum
+    assert data["es"]["pv_power"] == pytest.approx(354.6)
+    # Charging positive: importing 812 W + 354.6 W solar
+    assert data["es"]["bat_power"] == pytest.approx(354.6 + 812)
+
+
+async def test_venus_a_pv_fallback_on_dropped_poll(hass):
+    """A dropped PV.GetStatus reuses the last scaled strings."""
+    calls = {"n": 0}
+
+    def flaky_pv(**kwargs):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            return dict(venus_a_pv_status())
+        raise TimeoutError("device dropped the request")
+
+    api = make_api(pv_side_effect=flaky_pv)
+    coordinator = make_coordinator(hass, api)
+
+    first = await coordinator._async_update_data()
+    coordinator.data = first
+
+    second = await coordinator._async_update_data()
+
+    # Strings kept from the first poll, not re-scaled a second time
+    assert second["pv"]["pv1_power"] == 341.5
+    assert second["es"]["pv_power"] == pytest.approx(354.6)
+    assert second["es"]["bat_power"] == pytest.approx(354.6 + 812)
+
+
+async def test_venus_a_ac_only_when_no_pv_data(hass):
+    """Without any PV data the derivation falls back to the AC-side flows."""
+    api = make_api(pv_side_effect=lambda **kw: (_ for _ in ()).throw(TimeoutError()))
+    coordinator = make_coordinator(hass, api)
+
+    data = await coordinator._async_update_data()
+
+    assert "pv" not in data
+    # es.pv_power stays at the firmware value (0)
+    assert data["es"]["pv_power"] == 0
+    assert data["es"]["bat_power"] == pytest.approx(812)
+
+
+async def test_venus_e_path_unchanged(hass):
+    """Venus E: no PV polling on the fast tier, no bat_power synthesis."""
+    es = {
+        "id": 0,
+        "bat_power": 500,
+        "pv_power": 0,
+        "ongrid_power": -500,
+        "offgrid_power": 0,
+        "total_grid_input_energy": 100,
+        "total_grid_output_energy": 100,
+        "total_load_energy": 100,
+    }
+    api = make_api(model="VenusE", firmware=154, es=es)
+    coordinator = make_coordinator(hass, api, model="VenusE", firmware=154)
+
+    data = await coordinator._async_update_data()
+
+    api.get_pv_status.assert_not_awaited()
+    # fw 154: bat_power raw W, energies in centi-Wh (x100)
+    assert data["es"]["bat_power"] == 500.0
+    assert data["es"]["total_grid_input_energy"] == 10000.0
+    assert data["es"]["pv_power"] == 0
+
+
+async def test_staleness_uses_polling_tier(hass):
+    """em/mode stay fresh across their 300s polling gap; es does not."""
+    api = make_api()
+    coordinator = make_coordinator(hass, api)
+
+    now = time.time()
+    coordinator.category_last_updated = {
+        "es": now - 250,
+        "em": now - 250,
+        "mode": now - 250,
+        "pv": now - 250,
+    }
+
+    # base interval 60s, threshold 3: fast tier limit 180s, medium 900s
+    assert not coordinator.is_category_fresh("es")
+    assert coordinator.is_category_fresh("em")
+    assert coordinator.is_category_fresh("mode")
+    # Venus A polls pv on the fast tier -> stale at 250s
+    assert not coordinator.is_category_fresh("pv")
+
+
+async def test_staleness_pv_medium_tier_on_venus_d(hass):
+    api = make_api(model="VenusD", firmware=154)
+    coordinator = make_coordinator(hass, api, model="VenusD", firmware=154)
+
+    coordinator.category_last_updated = {"pv": time.time() - 250}
+    assert coordinator.is_category_fresh("pv")

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -229,3 +229,56 @@ class TestPvStringUnitDisambiguation:
 
     def test_missing_power_returns_none(self):
         assert _scale_pv_string_power(self.compat, {}, 1) is None
+
+
+class TestCircuitBreaker:
+    """Reduced polling pressure while the device answers nothing."""
+
+    @staticmethod
+    def dead_api():
+        api = MagicMock()
+        for name in (
+            "get_device_info", "get_es_status", "get_battery_status",
+            "get_pv_status", "get_em_status", "get_es_mode",
+            "get_wifi_status", "get_ble_status",
+        ):
+            setattr(api, name, AsyncMock(side_effect=TimeoutError("dead")))
+        return api
+
+    async def run_cycles(self, coordinator, n):
+        for _ in range(n):
+            coordinator.data = await coordinator._async_update_data()
+
+    async def test_reduces_to_single_probe_when_unresponsive(self, hass):
+        api = self.dead_api()
+        coordinator = make_coordinator(hass, api)
+
+        # first update + threshold full cycles
+        await self.run_cycles(coordinator, 4)
+        assert coordinator._consecutive_failed_cycles >= 3
+
+        es_before = api.get_es_status.await_count
+        bat_before = api.get_battery_status.await_count
+        await self.run_cycles(coordinator, 2)
+        # wedged cycles: exactly one es probe each, nothing else
+        assert api.get_es_status.await_count == es_before + 2
+        assert api.get_battery_status.await_count == bat_before
+        api.get_es_status.assert_awaited_with(timeout=5, max_attempts=1)
+
+    async def test_recovers_to_full_polling(self, hass):
+        api = self.dead_api()
+        coordinator = make_coordinator(hass, api)
+        await self.run_cycles(coordinator, 4)
+        assert coordinator._consecutive_failed_cycles >= 3
+
+        # device comes back
+        api.get_es_status = AsyncMock(side_effect=lambda **kw: dict(venus_a_es_status()))
+        api.get_battery_status = AsyncMock(side_effect=lambda **kw: dict(venus_a_battery_status()))
+        api.get_pv_status = AsyncMock(side_effect=lambda **kw: dict(venus_a_pv_status()))
+
+        coordinator.data = await coordinator._async_update_data()
+
+        assert coordinator._consecutive_failed_cycles == 0
+        # full cycle ran after the successful probe
+        assert api.get_battery_status.await_count == 1
+        assert coordinator.data["es"]["bat_power"] is not None

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -4,8 +4,10 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from custom_components.marstek_local_api.compatibility import CompatibilityMatrix
 from custom_components.marstek_local_api.coordinator import (
     MarstekDataUpdateCoordinator,
+    _scale_pv_string_power,
 )
 
 VENUS_A_DEVICE = {
@@ -33,7 +35,7 @@ def venus_a_es_status(ongrid=-812):
 
 
 def venus_a_pv_status():
-    # Raw per-string power in deci-W as returned by fw 148
+    # Raw per-string data as returned by fw 148 (power units differ per string!)
     return {
         "id": 0,
         "pv1_power": 3415, "pv1_voltage": 41, "pv1_current": 8, "pv1_state": 1,
@@ -100,13 +102,14 @@ async def test_venus_a_derives_pv_and_battery_power(hass):
 
     data = await coordinator._async_update_data()
 
-    # Per-string power scaled from deci-W at receipt
+    # Per-string unit disambiguated against V*I at receipt:
+    # pv1 raw 3415 @ 41V*8A=328 -> deci-W; pv2 raw 131 @ 42V*3A=126 -> plain W
     assert data["pv"]["pv1_power"] == 341.5
-    assert data["pv"]["pv2_power"] == 13.1
+    assert data["pv"]["pv2_power"] == 131.0
     # es.pv_power replaced by the string sum
-    assert data["es"]["pv_power"] == pytest.approx(354.6)
-    # Charging positive: importing 812 W + 354.6 W solar
-    assert data["es"]["bat_power"] == pytest.approx(354.6 + 812)
+    assert data["es"]["pv_power"] == pytest.approx(472.5)
+    # Charging positive: importing 812 W + 472.5 W solar
+    assert data["es"]["bat_power"] == pytest.approx(472.5 + 812)
 
 
 async def test_venus_a_pv_fallback_on_dropped_poll(hass):
@@ -129,8 +132,9 @@ async def test_venus_a_pv_fallback_on_dropped_poll(hass):
 
     # Strings kept from the first poll, not re-scaled a second time
     assert second["pv"]["pv1_power"] == 341.5
-    assert second["es"]["pv_power"] == pytest.approx(354.6)
-    assert second["es"]["bat_power"] == pytest.approx(354.6 + 812)
+    assert second["pv"]["pv2_power"] == 131.0
+    assert second["es"]["pv_power"] == pytest.approx(472.5)
+    assert second["es"]["bat_power"] == pytest.approx(472.5 + 812)
 
 
 async def test_venus_a_ac_only_when_no_pv_data(hass):
@@ -197,3 +201,31 @@ async def test_staleness_pv_medium_tier_on_venus_d(hass):
 
     coordinator.category_last_updated = {"pv": time.time() - 250}
     assert coordinator.is_category_fresh("pv")
+
+
+class TestPvStringUnitDisambiguation:
+    """Venus A fw 148 mixes deci-W and plain W between strings (live-observed)."""
+
+    compat = CompatibilityMatrix("Venus A", 148)
+
+    def test_deci_watt_string(self):
+        # live sample: raw 541 @ 47V*1A -> 54.1 W
+        pv = {"pv1_power": 541, "pv1_voltage": 47, "pv1_current": 1}
+        assert _scale_pv_string_power(self.compat, pv, 1) == 54.1
+
+    def test_plain_watt_string(self):
+        # live sample: raw 323 @ 40V*7A=280 -> 323 W (app shows 324)
+        pv = {"pv2_power": 323, "pv2_voltage": 40, "pv2_current": 7}
+        assert _scale_pv_string_power(self.compat, pv, 2) == 323.0
+
+    def test_low_reference_falls_back_to_matrix(self):
+        # V*I too small to discriminate -> matrix scaling (deci-W)
+        pv = {"pv1_power": 40, "pv1_voltage": 45, "pv1_current": 0}
+        assert _scale_pv_string_power(self.compat, pv, 1) == 4.0
+
+    def test_missing_voltage_falls_back_to_matrix(self):
+        pv = {"pv1_power": 541}
+        assert _scale_pv_string_power(self.compat, pv, 1) == 54.1
+
+    def test_missing_power_returns_none(self):
+        assert _scale_pv_string_power(self.compat, {}, 1) is None

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -1,8 +1,12 @@
 """Tests for per-model sensor gating and the per-string PV descriptions."""
 from types import SimpleNamespace
 
+import pytest
+
 from custom_components.marstek_local_api.compatibility import CompatibilityMatrix
 from custom_components.marstek_local_api.sensor import (
+    EnergyIntegrator,
+    INTEGRATED_ENERGY_SENSOR_TYPES,
     PV_STRING_SENSOR_TYPES,
     SENSOR_TYPES,
     VENUS_A_UNSUPPORTED_KEYS,
@@ -59,3 +63,53 @@ def test_pv_string_value_fns_bind_their_own_key():
 
 def test_pv_string_value_fn_handles_missing_data():
     assert PV_STRING_SENSOR_TYPES[0].value_fn({}) is None
+
+
+class TestEnergyIntegrator:
+    """Left-Riemann accumulation with gap and None handling."""
+
+    def test_accumulates_left_riemann(self):
+        integ = EnergyIntegrator(max_gap_seconds=180)
+        integ.add_sample(100.0, 1000.0)
+        # 100 W held for 60 s = 1.667 Wh, regardless of the new sample's value
+        assert integ.add_sample(500.0, 1060.0) == pytest.approx(100 * 60 / 3600)
+        # 500 W held for another 60 s
+        assert integ.add_sample(0.0, 1120.0) == pytest.approx((100 + 500) * 60 / 3600)
+
+    def test_gap_longer_than_max_is_skipped(self):
+        integ = EnergyIntegrator(max_gap_seconds=180)
+        integ.add_sample(100.0, 1000.0)
+        # 10-minute gap (restart / device offline): no accumulation
+        assert integ.add_sample(100.0, 1600.0) == 0.0
+        # but integration resumes afterwards
+        assert integ.add_sample(100.0, 1660.0) == pytest.approx(100 * 60 / 3600)
+
+    def test_none_power_pauses_accumulation(self):
+        integ = EnergyIntegrator(max_gap_seconds=180)
+        integ.add_sample(None, 1000.0)
+        assert integ.add_sample(100.0, 1060.0) == 0.0
+        assert integ.add_sample(None, 1120.0) == pytest.approx(100 * 60 / 3600)
+        # stale sample contributed nothing further
+        assert integ.add_sample(100.0, 1180.0) == pytest.approx(100 * 60 / 3600)
+
+    def test_non_positive_elapsed_ignored(self):
+        integ = EnergyIntegrator(max_gap_seconds=180)
+        integ.add_sample(100.0, 1000.0)
+        assert integ.add_sample(100.0, 1000.0) == 0.0
+        assert integ.add_sample(100.0, 990.0) == 0.0
+
+
+def test_integrated_energy_descriptions_split_power_by_sign():
+    descriptions = {d.key: d for d in INTEGRATED_ENERGY_SENSOR_TYPES}
+    assert set(descriptions) == {
+        "pv_energy_integrated",
+        "battery_energy_in_integrated",
+        "battery_energy_out_integrated",
+    }
+    charging = {"es": {"bat_power": 500, "pv_power": 120}}
+    discharging = {"es": {"bat_power": -300, "pv_power": 0}}
+    assert descriptions["battery_energy_in_integrated"].value_fn(charging) == 500
+    assert descriptions["battery_energy_in_integrated"].value_fn(discharging) == 0
+    assert descriptions["battery_energy_out_integrated"].value_fn(charging) == 0
+    assert descriptions["battery_energy_out_integrated"].value_fn(discharging) == 300
+    assert descriptions["pv_energy_integrated"].value_fn(charging) == 120

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -1,0 +1,61 @@
+"""Tests for per-model sensor gating and the per-string PV descriptions."""
+from types import SimpleNamespace
+
+from custom_components.marstek_local_api.compatibility import CompatibilityMatrix
+from custom_components.marstek_local_api.sensor import (
+    PV_STRING_SENSOR_TYPES,
+    SENSOR_TYPES,
+    VENUS_A_UNSUPPORTED_KEYS,
+    VENUS_A_ZERO_COUNTER_KEYS,
+    _standard_sensor_types,
+)
+
+
+def coordinator_stub(model, firmware):
+    return SimpleNamespace(compatibility=CompatibilityMatrix(model, firmware))
+
+
+def test_venus_a_skips_fields_the_firmware_never_sends():
+    keys = {d.key for d in _standard_sensor_types(coordinator_stub("Venus A", 148))}
+    assert keys & VENUS_A_UNSUPPORTED_KEYS == set()
+    # Everything else is still there
+    assert "battery_power" in keys
+    assert "battery_soc" in keys
+    assert "total_grid_import" in keys
+
+
+def test_venus_a_zero_counters_disabled_by_default():
+    descriptions = {
+        d.key: d for d in _standard_sensor_types(coordinator_stub("Venus A", 148))
+    }
+    for key in VENUS_A_ZERO_COUNTER_KEYS:
+        assert descriptions[key].entity_registry_enabled_default is False
+    # Working counters stay enabled
+    assert descriptions["total_grid_import"].entity_registry_enabled_default is True
+
+
+def test_other_models_get_unmodified_sensor_types():
+    for model, firmware in (("VenusE", 154), ("VenusE 3.0", 139), ("VenusD", 154), ("VenusC", 154)):
+        assert _standard_sensor_types(coordinator_stub(model, firmware)) is SENSOR_TYPES
+
+
+def test_pv_string_descriptions_cover_four_strings_without_current():
+    keys = {d.key for d in PV_STRING_SENSOR_TYPES}
+    expected = set()
+    for n in range(1, 5):
+        expected.add(f"pv{n}_power")
+        expected.add(f"pv{n}_voltage")
+    assert keys == expected
+
+
+def test_pv_string_value_fns_bind_their_own_key():
+    """Guard against the classic late-binding closure bug in the comprehension."""
+    data = {"pv": {f"pv{n}_power": float(n) for n in range(1, 5)}}
+    data["pv"].update({f"pv{n}_voltage": 10.0 * n for n in range(1, 5)})
+
+    for description in PV_STRING_SENSOR_TYPES:
+        assert description.value_fn(data) == data["pv"][description.key]
+
+
+def test_pv_string_value_fn_handles_missing_data():
+    assert PV_STRING_SENSOR_TYPES[0].value_fn({}) is None


### PR DESCRIPTION
To use this, add https://github.com/DatDraggy/ha-marstek-local-api in your HACS custom repositories temporarily until it was merged. For Venus A, the latest 1.0.0 and prerelease 1.2.0 version is broken.

Closes #48. Also addresses #98 / #128 (solar always 0), #125 (factor-10 energy counters), #56 / #88 (capacity and energy decimal placement on Venus A).

## What Venus A firmware actually returns (probed live, fw 148)

| Method | Differences vs Venus C/D/E |
| --- | --- |
| `ES.GetStatus` | **No `bat_power` field.** `pv_power` and `total_pv_energy` hardcoded `0`. `total_load_energy` hardcoded `0`. Energy counters in **plain Wh** (verified: counter rate 793 W vs 811 W measured AC flow). |
| `PV.GetStatus` | Per-string fields `pv1..pv4_power/_voltage/_current/_state` instead of the singular Venus D shape. String power **unit differs per string** — fw 148 reports pv1 in deci-W but pv2 in plain W in the same response (verified against V×I and the vendor app). The coordinator disambiguates each string against V×I. |
| `Bat.GetStatus` | No `bat_voltage`, `bat_current`, `error_code`. `bat_capacity`/`bat_temp` in plain Wh/°C. |
| `EM.GetStatus` | No `parse_state`. |
| `ES.GetMode` | Works; additionally embeds CT fields. |
| `ES.SetMode` | Works (modes, all 10 manual slots, passive). Device occasionally answers `set_result: false` when busy — retrying succeeds. |
| transport | Device silently drops UDP requests under load, rate-dependent: measured 20% dropped at 5 s request spacing, 33% at 2 s, 60% at 0.2 s bursts — with 0% ICMP loss on the same link. The existing 3-attempt retry usually gets through. |
| `Marstek.GetDevice` | Reports model `"Venus A"` (with space). `wifi_mac` can be the **access point's** MAC (AVM OUI observed), not the battery's own module. |

## Changes (one commit each)

- **compat:** new `"A"` hardware profile (plain-unit divisors + deci-W `pv_string_power`), detected from the model string.
- **coordinator:** Venus A polls `PV.GetStatus` every fast cycle (with last-known fallback for dropped requests), scales strings at receipt, sets `es.pv_power` to the string sum, and derives `es.bat_power = pv_power − ongrid_power − offgrid_power` (charging positive).
- **coordinator:** staleness window now based on each category's polling tier — fixes CT/mode sensors flapping to `unknown` between their ~300 s polls. ⚠️ Only cross-model behavior change in this PR (also relevant to #127).
- **sensor:** per-string PV entities for Venus A (`pv1..pv4` power/voltage; current omitted — plain A but integer resolution, too coarse to be useful); fields the firmware never sends are not created; always-zero energy counters created disabled-by-default.
- **manifest:** DHCP OUI `2CF8EC*` (Quectel module; confirmed via the battery's real DHCP MAC — the self-reported `wifi_mac` is unusable for this, see above).
- **diagnostics:** exports the selected compatibility profile.
- **sensor (2):** integrated solar / charged / discharged energy counters for Venus A - RestoreSensor-persisted Riemann sums of the derived powers, since the firmware's PV counter is stuck at 0 and its grid counters miss MPPT charging. Feeds the energy dashboard without user-side helpers. (Could be extended to other models later; kept Venus A-only here since C/E have working firmware counters.)
- **tests:** pytest suite (pytest-homeassistant-custom-component): 52 tests covering the compatibility matrix (all profiles), the Venus A derivation/fallback paths, staleness tiers, sensor gating, and config-flow abort paths; plus a CI workflow.
- **coordinator (2):** per-string PV power unit disambiguated against V×I — fw 148 mixes deci-W and plain W between strings of one response (verified against the vendor app); a fixed ÷10 showed one string 10× too low and skewed the derived powers.
- **docs:** README + DESIGN updates, including an energy-dashboard recipe (no firmware counter includes MPPT→battery charging).
- **config_flow:** `AbortFlow` from `_abort_if_unique_id_configured()` was caught by the broad exception handlers and logged as an ERROR — every DHCP lease renewal of an already-configured device (any model with a matched OUI) produced "Unexpected exception during DHCP discovery" + traceback (observed several times/day on a live install); the manual step showed "Unknown error" instead of "already configured". Now re-raised; 3 regression tests added.

## Verified live (Venus A, fw 148)

- Read path: all sensors correct through charge→discharge transitions; solar power = exact sum of the disambiguated strings (cross-checked against the vendor app per string); derived battery power matched a 200 W manual discharge exactly (PV passthrough + battery on the AC port). 25-min soak: zero `unknown` flaps on mode/CT/power sensors.
- Write path: Auto/AI/Manual buttons (device-side read-back via `ES.GetMode` each time), `set_manual_schedule` (inert + live discharge), `clear_manual_schedules` across all 10 slots, `set_passive_mode` in both directions (discharge +200 W and charge −150 W, each matching the AC flows exactly) incl. `cd_time` auto-revert.
- Endpoint sweep (the repo's `discover_api.py` candidates): all 29 schedule/config read-back candidates return `-32601` — schedules remain write-only on this firmware.

## Related open PRs

- #53 proposes the same staleness-tier fix as a static factor dict; this branch implements it as a method because Venus A needs `pv` on the fast tier while Venus D keeps it on the medium tier (credited in the commit message). Happy to defer to #53 + a small follow-up if you prefer.
- #34 also adds pytest scaffolding; if it lands first I'll rebase my tests onto its layout.
- #124 adds `(HW 3.0, fw 148)` scaling entries — that's Venus E v3, unrelated to the Venus A profile here; only trivial merge conflicts in `compatibility.py` expected.

## Not included / follow-ups

- `pvN_current` sensors (plain A but integer resolution — too coarse to be useful).